### PR TITLE
etcd: Refactor

### DIFF
--- a/projects/etcd/build.sh
+++ b/projects/etcd/build.sh
@@ -8,14 +8,13 @@ cd $SRC/etcd/server/storage/backend/testing
 mv $SRC/cncf-fuzzing/projects/etcd/backend_fuzzer.go ./
 pwd
 go get github.com/AdaLogics/go-fuzz-headers
-go-fuzz -tags gofuzz -func FuzzBackend -o FuzzBackend.a .
-$CXX $CXXFLAGS $LIB_FUZZING_ENGINE FuzzBackend.a -lpthread -o $OUT/fuzz_backend
+compile_go_fuzzer go.etcd.io/etcd/server/v3/storage/backend/testing FuzzBackend fuzz_backend
 
 # grpc api fuzzer
 mkdir $SRC/etcd/tests/fuzzing
 mv $SRC/cncf-fuzzing/projects/etcd/v3_grpc_fuzzer.go $SRC/etcd/tests/fuzzing/
 cd $SRC/etcd/tests/fuzzing
-sed -i '219d' $SRC/etcd/tests/framework/integration/cluster.go
+sed -i '220d' $SRC/etcd/tests/framework/integration/cluster.go
 compile_go_fuzzer . FuzzGRPCApis fuzz_grpc_apis
 cd -
 
@@ -27,12 +26,9 @@ mv $SRC/etcd/server/etcdserver/api/rafthttp/functional_test.go \
 
 cd $SRC/etcd/server/etcdserver/api/rafthttp
 go mod tidy
+compile_go_fuzzer go.etcd.io/etcd/server/v3/etcdserver/api/rafthttp FuzzRaftHttpRequests fuzz_raft_http_requests
 
-go-fuzz -tags gofuzz -func FuzzRaftHttpRequests -o FuzzRaftHttpRequests.a .
-$CXX $CXXFLAGS $LIB_FUZZING_ENGINE FuzzRaftHttpRequests.a -lpthread -o $OUT/fuzz_raft_http_requests
-
-go-fuzz -tags gofuzz -func FuzzMessageEncodeDecode -o FuzzMessageEncodeDecode.a .
-$CXX $CXXFLAGS $LIB_FUZZING_ENGINE FuzzMessageEncodeDecode.a -lpthread -o $OUT/fuzz_message_encode_decode
+compile_go_fuzzer go.etcd.io/etcd/server/v3/etcdserver/api/rafthttp FuzzMessageEncodeDecode fuzz_message_encode_decode
 
 # raft fuzzer
 cd $SRC/etcd/raft
@@ -42,16 +38,13 @@ mv diff_test.go diff_test_fuzz.go
 mv log_test.go log_test_fuzz.go
 mv raft_test.go raft_test_fuzz.go
 
-go-fuzz -tags gofuzz -func FuzzNetworkSend -o FuzzNetworkSend.a .
-$CXX $CXXFLAGS $LIB_FUZZING_ENGINE FuzzNetworkSend.a -lpthread -o $OUT/fuzz_network_send
+compile_go_fuzzer go.etcd.io/etcd/raft/v3 FuzzNetworkSend fuzz_network_send
 
-go-fuzz -tags gofuzz -func FuzzStep -o FuzzStep.a .
-$CXX $CXXFLAGS $LIB_FUZZING_ENGINE FuzzStep.a -lpthread -o $OUT/fuzz_step
+compile_go_fuzzer go.etcd.io/etcd/raft/v3 FuzzStep fuzz_step
 
 # v2auth fuzzer
 cd $SRC/etcd/server/etcdserver/api/v2auth
 mv $SRC/cncf-fuzzing/projects/etcd/v2auth_fuzzer.go ./
 mv auth_test.go auth_test_fuzz.go
 
-go-fuzz -tags gofuzz -func FuzzCreateOrUpdateUser -o FuzzCreateOrUpdateUser.a .
-$CXX $CXXFLAGS $LIB_FUZZING_ENGINE FuzzCreateOrUpdateUser.a -lpthread -o $OUT/fuzz_create_or_update_user
+compile_go_fuzzer go.etcd.io/etcd/server/v3/etcdserver/api/v2auth FuzzCreateOrUpdateUser FuzzCreateOrUpdateUser


### PR DESCRIPTION
1. Switches the build of the fuzzers to OSS-fuzz's `compile_go_fuzzer`.
2. Use module paths instead of `.`