### PR TITLE
kubernetes: Refactor fuzzers

### DIFF
--- a/projects/kubernetes/aes_fuzzer.go
+++ b/projects/kubernetes/aes_fuzzer.go
@@ -20,10 +20,12 @@ import (
 	"crypto/cipher"
 	"encoding/hex"
 	"fmt"
+	"reflect"
+
 	fuzz "github.com/AdaLogics/go-fuzz-headers"
+
 	"k8s.io/apiserver/pkg/storage/value"
 	aestransformer "k8s.io/apiserver/pkg/storage/value/encrypt/aes"
-	"reflect"
 )
 
 func FuzzAesRoundtrip(data []byte) int {

--- a/projects/kubernetes/apiextensions_fuzzer.go
+++ b/projects/kubernetes/apiextensions_fuzzer.go
@@ -19,7 +19,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync"
+
 	fuzz "github.com/AdaLogics/go-fuzz-headers"
+
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apiServerValidation "k8s.io/apiextensions-apiserver/pkg/apiserver/validation"
@@ -31,7 +34,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/json"
 	"k8s.io/client-go/util/jsonpath"
 	kubeopenapispec "k8s.io/kube-openapi/pkg/validation/spec"
-	"sync"
 )
 
 var scheme = runtime.NewScheme()

--- a/projects/kubernetes/apiserver_fuzzer.go
+++ b/projects/kubernetes/apiserver_fuzzer.go
@@ -18,7 +18,9 @@ package fuzzing
 import (
 	"encoding/json"
 	"fmt"
+
 	fuzz "github.com/AdaLogics/go-fuzz-headers"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	auditpolicy "k8s.io/apiserver/pkg/audit/policy"
 )

--- a/projects/kubernetes/build.sh
+++ b/projects/kubernetes/build.sh
@@ -41,8 +41,10 @@ cp $SRC/cncf-fuzzing/projects/kubernetes/*.go \
 
 
 go mod tidy && go mod vendor
+# disable this fuzzer for now
+#compile_go_fuzzer k8s.io/kubernetes/pkg/kubelet/server FuzzRequest fuzz_request
+
 compile_go_fuzzer k8s.io/kubernetes/test/fuzz/fuzzing FuzzApiMarshaling fuzz_api_marshaling
-compile_go_fuzzer k8s.io/kubernetes/pkg/kubelet/server FuzzRequest fuzz_request
 compile_go_fuzzer k8s.io/kubernetes/pkg/kubelet/kuberuntime FuzzKubeRuntime fuzz_kube_runtime
 compile_go_fuzzer k8s.io/kubernetes/pkg/kubelet FuzzSyncPod fuzz_sync_pod
 compile_go_fuzzer k8s.io/kubernetes/pkg/kubelet FuzzStrategicMergePatch fuzz_strategic_merge_patch

--- a/projects/kubernetes/converter_fuzzer.go
+++ b/projects/kubernetes/converter_fuzzer.go
@@ -17,11 +17,12 @@ package fuzzing
 
 import (
 	"fmt"
+	"reflect"
+	"time"
+
 	"k8s.io/apimachinery/pkg/conversion"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/json"
-	"reflect"
-	"time"
 )
 
 type A struct {

--- a/projects/kubernetes/deepcopy_fuzzer.go
+++ b/projects/kubernetes/deepcopy_fuzzer.go
@@ -18,10 +18,12 @@ package fuzzing
 import (
 	"bytes"
 	"reflect"
+
 	fuzz "github.com/AdaLogics/go-fuzz-headers"
-	"k8s.io/kubernetes/pkg/api/legacyscheme"
-	"k8s.io/apimachinery/pkg/runtime/schema"
+
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/kubernetes/pkg/api/legacyscheme"
 )
 
 func FuzzDeepCopy(data []byte) int {
@@ -68,4 +70,3 @@ func doDeepCopyTest(kind schema.GroupVersionKind, f *fuzz.ConsumeFuzzer) error {
 	}
 	return nil
 }
-

--- a/projects/kubernetes/gofuzz-fuzzers.go
+++ b/projects/kubernetes/gofuzz-fuzzers.go
@@ -20,8 +20,9 @@ import (
 	"encoding/binary"
 	"io"
 	"math/rand"
-	//fuzz "github.com/google/gofuzz"
-	//"github.com/google/gofuzz/bytesource"
+	"sync"
+	"testing"
+
 	"k8s.io/apimachinery/pkg/api/apitesting/fuzzer"
 	"k8s.io/apimachinery/pkg/api/apitesting/roundtrip"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -35,8 +36,6 @@ import (
 	kubeletScheme "k8s.io/kubernetes/pkg/kubelet/apis/config/scheme"
 	proxyFuzzer "k8s.io/kubernetes/pkg/proxy/apis/config/fuzzer"
 	proxyScheme "k8s.io/kubernetes/pkg/proxy/apis/config/scheme"
-	"sync"
-	"testing"
 )
 
 type ByteSource struct {

--- a/projects/kubernetes/kubectl_fuzzer.go
+++ b/projects/kubernetes/kubectl_fuzzer.go
@@ -17,17 +17,19 @@ package fuzzing
 
 import (
 	"fmt"
-	fuzz "github.com/AdaLogics/go-fuzz-headers"
 	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+
+	fuzz "github.com/AdaLogics/go-fuzz-headers"
+	"sigs.k8s.io/yaml"
+
 	"k8s.io/kubectl/pkg/apply"
 	"k8s.io/kubectl/pkg/apply/parse"
 	"k8s.io/kubectl/pkg/apply/strategy"
 	tst "k8s.io/kubectl/pkg/util/openapi/testing"
-	"net/http"
-	"os"
-	"path/filepath"
-	"sigs.k8s.io/yaml"
-	"strings"
 )
 
 var (

--- a/projects/kubernetes/kubelet_fuzzer.go
+++ b/projects/kubernetes/kubelet_fuzzer.go
@@ -18,14 +18,16 @@ package fuzzing
 import (
 	"bytes"
 	"context"
+	"os"
+	"time"
+
 	fuzz "github.com/AdaLogics/go-fuzz-headers"
+
 	"k8s.io/api/core/v1"
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 	apitesting "k8s.io/cri-api/pkg/apis/testing"
 	"k8s.io/kubernetes/pkg/kubelet/kubeletconfig/checkpoint"
 	"k8s.io/kubernetes/pkg/kubelet/kuberuntime/logs"
-	"os"
-	"time"
 )
 
 func FuzzDecodeRemoteConfigSource(data []byte) int {

--- a/projects/kubernetes/parser_fuzzer.go
+++ b/projects/kubernetes/parser_fuzzer.go
@@ -16,8 +16,10 @@
 package fuzzing
 
 import (
-	fuzz "github.com/AdaLogics/go-fuzz-headers"
 	"io"
+
+	fuzz "github.com/AdaLogics/go-fuzz-headers"
+
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"

--- a/projects/kubernetes/roundtrip_fuzzer.go
+++ b/projects/kubernetes/roundtrip_fuzzer.go
@@ -16,13 +16,15 @@
 package fuzzing
 
 import (
-	fuzz "github.com/AdaLogics/go-fuzz-headers"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	"reflect"
 	"sync"
 	"testing"
+
+	fuzz "github.com/AdaLogics/go-fuzz-headers"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/kubernetes/pkg/api/legacyscheme"
 
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"

--- a/projects/kubernetes/validation_fuzzer.go
+++ b/projects/kubernetes/validation_fuzzer.go
@@ -17,6 +17,7 @@ package fuzzing
 
 import (
 	fuzz "github.com/AdaLogics/go-fuzz-headers"
+
 	v1 "k8s.io/api/core/v1"
 	policyv1beta1 "k8s.io/api/policy/v1beta1"
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"


### PR DESCRIPTION
1. Applies `gofmt` and `goimports`.
2. Removes inline comments
3. Disables the `FuzzRequest` fuzzer as it is not suited yet to run continuously.