### PR TITLE
etcd: Refactor raft fuzzers

### DIFF
--- a/projects/etcd/build.sh
+++ b/projects/etcd/build.sh
@@ -55,8 +55,6 @@ mv diff_test.go diff_test_fuzz.go
 mv log_test.go log_test_fuzz.go
 mv raft_test.go raft_test_fuzz.go
 
-compile_go_fuzzer go.etcd.io/etcd/raft/v3 FuzzNetworkSend fuzz_network_send
-
 compile_go_fuzzer go.etcd.io/etcd/raft/v3 FuzzStep fuzz_step
 
 # v2auth fuzzer

--- a/projects/etcd/raft_fuzzer.go
+++ b/projects/etcd/raft_fuzzer.go
@@ -18,40 +18,87 @@ package raft
 import (
 	fuzz "github.com/AdaLogics/go-fuzz-headers"
 	pb "go.etcd.io/etcd/raft/v3/raftpb"
+	"runtime"
+	"strings"
 )
 
-func FuzzNetworkSend(data []byte) int {
-	f := fuzz.NewConsumer(data)
-	msg := pb.Message{}
-	err := f.GenerateStruct(&msg)
-	if err != nil {
-		return 0
+func getMsgType(i int) pb.MessageType {
+	allTypes := map[int]pb.MessageType{0: pb.MsgHup,
+		1:  pb.MsgBeat,
+		2:  pb.MsgProp,
+		3:  pb.MsgApp,
+		4:  pb.MsgAppResp,
+		5:  pb.MsgVote,
+		6:  pb.MsgVoteResp,
+		7:  pb.MsgSnap,
+		8:  pb.MsgHeartbeat,
+		9:  pb.MsgHeartbeatResp,
+		10: pb.MsgUnreachable,
+		11: pb.MsgSnapStatus,
+		12: pb.MsgCheckQuorum,
+		13: pb.MsgTransferLeader,
+		14: pb.MsgTimeoutNow,
+		15: pb.MsgReadIndex,
+		16: pb.MsgReadIndexResp,
+		17: pb.MsgPreVote,
+		18: pb.MsgPreVoteResp}
+	return allTypes[i%len(allTypes)]
+}
+
+// All cases in shouldReport represent known errors in etcd
+// as these are reported via manually added panics.
+func shouldReport(err string) bool {
+	if strings.Contains(err, "stepped empty MsgProp") {
+		return false
+	}
+	if strings.Contains(err, "Was the raft log corrupted, truncated, or lost?") {
+		return false
+	}
+	if strings.Contains(err, "ConfStates not equivalent after sorting:") {
+		return false
+	}
+	if strings.Contains(err, "term should be set when sending ") {
+		return false
+	}
+	if (strings.Contains(err, "unable to restore config")) && (strings.Contains(err, "removed all voters")) {
+		return false
 	}
 
-	n1 := newTestLearnerRaft(1, 10, 1, newTestMemoryStorage(withPeers(1), withLearners(2)))
-	n2 := newTestLearnerRaft(2, 10, 1, newTestMemoryStorage(withPeers(1), withLearners(2)))
+	return true
+}
 
-	nt := newNetwork(n1, n2)
-
-	n1.becomeFollower(1, None)
-	n2.becomeFollower(1, None)
-
-	setRandomizedElectionTimeout(n1, n1.electionTimeout)
-	for i := 0; i < n1.electionTimeout; i++ {
-		n1.tick()
+func catchPanics() {
+	if r := recover(); r != nil {
+		var err string
+		switch r.(type) {
+		case string:
+			err = r.(string)
+		case runtime.Error:
+			err = r.(runtime.Error).Error()
+		}
+		if shouldReport(err) {
+			// Getting to this point means that the fuzzer
+			// did not stop because of a manually added panic.
+			panic(err)
+		}
 	}
-
-	nt.send(msg)
-	return 1
 }
 
 func FuzzStep(data []byte) int {
+	defer catchPanics()
 	f := fuzz.NewConsumer(data)
 	msg := pb.Message{}
 	err := f.GenerateStruct(&msg)
 	if err != nil {
 		return 0
 	}
+
+	msgTypeIndex, err := f.GetInt()
+	if err != nil {
+		return 0
+	}
+	msg.Type = getMsgType(msgTypeIndex)
+
 	r := newTestRaft(1, 5, 1, newTestMemoryStorage(withPeers(1, 2)))
 	r.becomeCandidate()
 	r.becomeLeader()


### PR DESCRIPTION
1. Removes `FuzzNetworkSend`
2. Ensures correct msg type on every iteration.
3. Prevents the fuzzer from crashing from known errors in etcd by recovering manually added panics.