### PR TITLE
etcd: Add proxy fuzzer

### DIFF
--- a/projects/etcd/build.sh
+++ b/projects/etcd/build.sh
@@ -2,6 +2,12 @@
 sed -i '/FORBIDDEN_DEPENDENCY/d' $SRC/etcd/server/go.mod
 sed -i '/FORBIDDEN_DEPENDENCY/d' $SRC/etcd/raft/go.mod
 
+# proxy fuzzer
+cd $SRC/etcd/pkg/proxy
+mv server_test.go server_test_fuzz.go
+mv $SRC/cncf-fuzzing/projects/etcd/proxy_fuzzer.go ./
+compile_go_fuzzer go.etcd.io/etcd/pkg/v3/proxy FuzzProxyServer fuzz_proxy_server
+
 # etcdserver fuzzer
 echo "building etcdserver fuzzer"
 cd $SRC/etcd/server/etcdserver

--- a/projects/etcd/proxy_fuzzer.go
+++ b/projects/etcd/proxy_fuzzer.go
@@ -1,0 +1,55 @@
+// Copyright 2021 ADA Logics Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package proxy
+
+import (
+	"net/url"
+	"os"
+	"testing"
+
+	"go.etcd.io/etcd/client/pkg/v3/transport"
+	"go.uber.org/zap"
+)
+
+func init() {
+	testing.Init()
+}
+
+var fuzzLogger = zap.NewExample()
+
+func FuzzProxyServer(data []byte) int {
+	t := &testing.T{}
+	scheme := "unix"
+	srcAddr, dstAddr := newUnixAddr(), newUnixAddr()
+	defer func() {
+		os.RemoveAll(srcAddr)
+		os.RemoveAll(dstAddr)
+	}()
+	tlsInfo := transport.TLSInfo{}
+	ln := listen(t, scheme, dstAddr, transport.TLSInfo{})
+	defer ln.Close()
+
+	p := NewServer(ServerConfig{
+		Logger: fuzzLogger,
+		From:   url.URL{Scheme: scheme, Host: srcAddr},
+		To:     url.URL{Scheme: scheme, Host: dstAddr},
+	})
+	<-p.Ready()
+	defer p.Close()
+
+	send(t, data, scheme, srcAddr, tlsInfo)
+	return 1
+}


### PR DESCRIPTION
Adds a fuzzer that sets up a proxy server and passes pseudo-random data to it.

This fuzzer tests the `etcd/pkg/proxy` package.