### PR TITLE
argo: Move fuzzers to cncf-fuzzing

### DIFF
--- a/projects/argo/build.sh
+++ b/projects/argo/build.sh
@@ -1,0 +1,33 @@
+#!/bin/bash -eu
+# Copyright 2021 ADA Logics Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+mv $SRC/cncf-fuzzing/projects/argo/sessionmanager_fuzzer.go $SRC/argo-cd/util/session/
+mv $SRC/argo-cd/util/session/sessionmanager_test.go $SRC/argo-cd/util/session/sessionmanager_fuzz.go
+compile_go_fuzzer github.com/argoproj/argo-cd/v2/util/session FuzzSessionmanagerParse fuzz_sessionmanager_parse
+compile_go_fuzzer github.com/argoproj/argo-cd/v2/util/session FuzzVerifyUsernamePassword fuzz_verify_username_password
+
+mv $SRC/cncf-fuzzing/projects/argo/repository_fuzzer.go $SRC/argo-cd/reposerver/repository/
+compile_go_fuzzer github.com/argoproj/argo-cd/v2/reposerver/repository FuzzGenerateManifests fuzz_generate_manifests
+
+mv $SRC/cncf-fuzzing/projects/argo/normalizer_fuzzer.go $SRC/argo-cd/util/argo/normalizers/
+compile_go_fuzzer github.com/argoproj/argo-cd/v2/util/argo/normalizers FuzzNormalize fuzz_normalize
+
+mv $SRC/cncf-fuzzing/projects/argo/workflow_validation_fuzzer.go $SRC/argo-workflows/workflow/validate/
+cd $SRC/argo-workflows
+compile_go_fuzzer github.com/argoproj/argo-workflows/v3/workflow/validate FuzzValidateWorkflow fuzz_validate_workflow
+
+mv $SRC/cncf-fuzzing/projects/argo/workflow_parser_fuzzer.go $SRC/argo-workflows/workflow/common/
+compile_go_fuzzer github.com/argoproj/argo-workflows/v3/workflow/common FuzzParseObjects fuzz_parse_objects

--- a/projects/argo/normalizer_fuzzer.go
+++ b/projects/argo/normalizer_fuzzer.go
@@ -1,0 +1,79 @@
+// Copyright 2021 ADA Logics Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package normalizers
+
+import (
+	"encoding/json"
+	"strings"
+
+	fuzz "github.com/AdaLogics/go-fuzz-headers"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/yaml"
+
+	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
+)
+
+func UnstructuredForFuzzing(text string) (*unstructured.Unstructured, error) {
+	un := &unstructured.Unstructured{}
+	var err error
+	if strings.HasPrefix(text, "{") {
+		err = json.Unmarshal([]byte(text), &un)
+	} else {
+		err = yaml.Unmarshal([]byte(text), &un)
+	}
+	if err != nil {
+		return nil, err
+	}
+	return un, nil
+}
+
+func FuzzNormalize(data []byte) int {
+	f := fuzz.NewConsumer(data)
+	ignore := make([]v1alpha1.ResourceIgnoreDifferences, 0)
+	noOfIgnores, err := f.GetInt()
+	if err != nil {
+		return 0
+	}
+	for i := 0; i < noOfIgnores%30; i++ {
+		ign := v1alpha1.ResourceIgnoreDifferences{}
+		err = f.GenerateStruct(&ign)
+		if err != nil {
+			return 0
+		}
+		ignore = append(ignore, ign)
+	}
+
+	overrides := make(map[string]v1alpha1.ResourceOverride)
+	err = f.FuzzMap(&overrides)
+	if err != nil {
+		return 0
+	}
+
+	unstructuredData, err := f.GetString()
+	if err != nil {
+		return 0
+	}
+	un, err := UnstructuredForFuzzing(unstructuredData)
+	if err != nil {
+		return 0
+	}
+	normalizer, err := NewIgnoreNormalizer(ignore, overrides)
+	if err != nil {
+		return 0
+	}
+	_ = normalizer.Normalize(un)
+	return 1
+}

--- a/projects/argo/repository_fuzzer.go
+++ b/projects/argo/repository_fuzzer.go
@@ -1,0 +1,42 @@
+// Copyright 2021 ADA Logics Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package repository
+
+import (
+	"os"
+
+	fuzz "github.com/AdaLogics/go-fuzz-headers"
+
+	argoappv1 "github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
+	"github.com/argoproj/argo-cd/v2/reposerver/apiclient"
+)
+
+func FuzzGenerateManifests(data []byte) int {
+	dir, err := os.MkdirTemp("", "fuzz-")
+	if err != nil {
+		return 0
+	}
+	defer os.RemoveAll(dir)
+	f := fuzz.NewConsumer(data)
+	err = f.CreateFiles(dir)
+	if err != nil {
+		return 0
+	}
+	src := argoappv1.ApplicationSource{Path: "manifests/base"}
+	q := apiclient.ManifestRequest{Repo: &argoappv1.Repository{}, ApplicationSource: &src}
+	_, _ = GenerateManifests(dir, "/", "", &q, false)
+	return 1
+}

--- a/projects/argo/sessionmanager_fuzzer.go
+++ b/projects/argo/sessionmanager_fuzzer.go
@@ -1,0 +1,51 @@
+// Copyright 2021 ADA Logics Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package session
+
+import (
+	"context"
+	"testing"
+
+	"github.com/argoproj/argo-cd/v2/test"
+	"github.com/argoproj/argo-cd/v2/util/settings"
+)
+
+var (
+	mgr *SessionManager
+)
+
+func init() {
+	testing.Init()
+	redisClient, _ := test.NewInMemoryRedis()
+
+	settingsMgr := settings.NewSettingsManager(context.Background(), getKubeClient("pass", true), "argocd")
+	mgr = newSessionManager(settingsMgr, getProjLister(), NewUserStateStorage(redisClient))
+}
+
+func FuzzSessionmanagerParse(data []byte) int {
+	_, _, _ = mgr.VerifyToken(string(data))
+	return 1
+}
+
+func FuzzVerifyUsernamePassword(data []byte) int {
+	if !(len(data)%2 == 0) || len(data) < 10 {
+		return 0
+	}
+	username := string(data[0 : len(data)/2])
+	password := string(data[(len(data)/2)+1:])
+	_ = mgr.VerifyUsernamePassword(username, password)
+	return 1
+}

--- a/projects/argo/workflow_parser_fuzzer.go
+++ b/projects/argo/workflow_parser_fuzzer.go
@@ -1,0 +1,22 @@
+// Copyright 2021 ADA Logics Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package common
+
+func FuzzParseObjects(data []byte) int {
+	_ = ParseObjects(data, false)
+	_ = ParseObjects(data, true)
+	return 1
+}

--- a/projects/argo/workflow_validation_fuzzer.go
+++ b/projects/argo/workflow_validation_fuzzer.go
@@ -1,0 +1,43 @@
+// Copyright 2021 ADA Logics Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package validate
+
+import (
+	fuzz "github.com/AdaLogics/go-fuzz-headers"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	wfv1 "github.com/argoproj/argo-workflows/v3/pkg/apis/workflow/v1alpha1"
+	fakewfclientset "github.com/argoproj/argo-workflows/v3/pkg/client/clientset/versioned/fake"
+	"github.com/argoproj/argo-workflows/v3/workflow/templateresolution"
+)
+
+var (
+	wfClientsetFuzz   = fakewfclientset.NewSimpleClientset()
+	wftmplGetterFuzz  = templateresolution.WrapWorkflowTemplateInterface(wfClientsetFuzz.ArgoprojV1alpha1().WorkflowTemplates(metav1.NamespaceDefault))
+	cwftmplGetterFuzz = templateresolution.WrapClusterWorkflowTemplateInterface(wfClientsetFuzz.ArgoprojV1alpha1().ClusterWorkflowTemplates())
+)
+
+func FuzzValidateWorkflow(data []byte) int {
+	f := fuzz.NewConsumer(data)
+	wf := &wfv1.Workflow{}
+	err := f.GenerateStruct(wf)
+	if err != nil {
+		return 0
+	}
+	opts := ValidateOpts{}
+	_, _ = ValidateWorkflow(wftmplGetterFuzz, cwftmplGetterFuzz, wf, opts)
+	return 1
+}


### PR DESCRIPTION
Moves the fuzzers at https://github.com/google/oss-fuzz/tree/master/projects/argo over to cncf-fuzzing.

Also adds a few more fuzzers.