### PR TITLE
distribution: Clean up and add more fuzzers

### DIFF
--- a/projects/distribution/authchallenge_fuzzer.go
+++ b/projects/distribution/authchallenge_fuzzer.go
@@ -13,9 +13,9 @@
 // limitations under the License.
 //
 
-package reference
+package challenge
 
-func FuzzParseNormalizedNamed(data []byte) int {
-	_, _ = ParseNormalizedNamed(string(data))
+func FuzzParseValueAndParams(data []byte) int {
+	_, _ = parseValueAndParams(string(data))
 	return 1
 }

--- a/projects/distribution/build.sh
+++ b/projects/distribution/build.sh
@@ -1,13 +1,15 @@
+set -o nounset
+set -o pipefail
+set -o errexit
+set -x
 
 export CNCFPATH="${SRC}/"cncf-fuzzing/projects/distribution
 export DISTRIBUTION="github.com/distribution/distribution/v3"
 export REGISTRYPATH="${DISTRIBUTION}/registry"
 
+$SRC/distribution/script/oss_fuzz_build.sh
+
 mv $CNCFPATH/inmemory_fuzzer.go $SRC/distribution/registry/storage/driver/inmemory/
-
-mv $CNCFPATH/reference_fuzzer.go $SRC/distribution/reference/
-
-mv $CNCFPATH/api_v2_fuzzer.go $SRC/distribution/registry/api/v2/
 
 mv $CNCFPATH/registry_fuzzer.go $SRC/distribution/registry/
 mv $SRC/distribution/registry/registry_test.go \
@@ -27,16 +29,22 @@ mv $CNCFPATH/s3_aws_fuzzer.go $SRC/distribution/registry/storage/driver/s3-aws/
 
 mv $CNCFPATH/ocischema_fuzzer.go $SRC/distribution/manifest/ocischema/
 
+mv $CNCFPATH/authchallenge_fuzzer.go $SRC/distribution/registry/client/auth/challenge/
+mv $CNCFPATH/token_fuzzer.go $SRC/distribution/registry/auth/token/
+
 go mod tidy && go mod vendor
-compile_go_fuzzer $DISTRIBUTION/reference FuzzParseNormalizedNamed fuzz_parsed_normalized_named
+compile_go_fuzzer $DISTRIBUTION/reference FuzzParseNormalizedNamed fuzz_parse_normalized_named
 compile_go_fuzzer $DISTRIBUTION/manifest/ocischema FuzzManifestBuilder fuzz_manifest_builder
 
+compile_go_fuzzer $REGISTRYPATH/auth/token FuzzToken fuzz_token
+compile_go_fuzzer $REGISTRYPATH/client/auth/challenge FuzzParseValueAndParams fuzz_parse_value_and_params
 compile_go_fuzzer $REGISTRYPATH FuzzRegistry1 fuzz_registry1
 compile_go_fuzzer $REGISTRYPATH FuzzRegistry2 fuzz_registry2
-compile_go_fuzzer $REGISTRYPATH/api/v2/ FuzzParseForwardedHeader fuzz_parse_forwarded_header
 compile_go_fuzzer $REGISTRYPATH/client FuzzBlobServeBlob fuzz_blob_serve_blob
+compile_go_fuzzer $REGISTRYPATH/client FuzzClientPut fuzz_client_put
 compile_go_fuzzer $REGISTRYPATH/storage FuzzSchema2ManifestHandler fuzz_schema2_manifest_handler
 compile_go_fuzzer $REGISTRYPATH/storage FuzzBlob fuzz_blob
+compile_go_fuzzer $REGISTRYPATH/storage FuzzMarkAndSweep fuzz_mark_and_sweep
 compile_go_fuzzer $REGISTRYPATH/storage FuzzFR fuzz_fr
 compile_go_fuzzer $REGISTRYPATH/storage/driver/inmemory FuzzInmemoryDriver fuzz_inmemory_driver
 compile_go_fuzzer $REGISTRYPATH/storage/driver/s3-aws FuzzS3Driver fuzz_s3_driver

--- a/projects/distribution/inmemory_fuzzer.go
+++ b/projects/distribution/inmemory_fuzzer.go
@@ -28,7 +28,7 @@ func FuzzInmemoryDriver(data []byte) int {
 	if err != nil {
 		return 0
 	}
-	maxExecs := noOfExecs % 100
+	maxExecs := noOfExecs % 10
 	for i := 0; i < maxExecs; i++ {
 		err = doRandomOp(d, f)
 		if err != nil {

--- a/projects/distribution/token_fuzzer.go
+++ b/projects/distribution/token_fuzzer.go
@@ -13,9 +13,28 @@
 // limitations under the License.
 //
 
-package v2
+package token
 
-func FuzzParseForwardedHeader(data []byte) int {
-	_, _, _ = parseForwardedHeader(string(data))
+import (
+	fuzz "github.com/AdaLogics/go-fuzz-headers"
+)
+
+func FuzzToken(data []byte) int {
+	f := fuzz.NewConsumer(data)
+	rawToken, err := f.GetString()
+	if err != nil {
+		return 0
+	}
+	verifyOps := VerifyOptions{}
+	err = f.GenerateStruct(&verifyOps)
+	if err != nil {
+		return 0
+	}
+	token, err := NewToken(rawToken)
+	if err != nil {
+		return 0
+	}
+	token.Verify(verifyOps)
+	_, _ = token.VerifySigningKey(verifyOps)
 	return 1
 }


### PR DESCRIPTION
1. Delete fuzzers here that are merged upstream
2. Build upstream fuzzers
3. Add more fuzzers
4. Reduce `noOfExecs` in inmemory fuzzer
5. Do so that if any fuzzer fails to be built, it gets reported in OSS-fuzz.