### PR TITLE
[Argo]: Change import in fuzzer due to upstream change

### DIFF
--- a/projects/argo/project_fuzzer.go
+++ b/projects/argo/project_fuzzer.go
@@ -17,7 +17,7 @@ package project
 
 import (
 	fuzz "github.com/AdaLogics/go-fuzz-headers"
-	"github.com/dgrijalva/jwt-go/v4"
+	"github.com/golang-jwt/jwt/v4"
 
 	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 )


### PR DESCRIPTION
Please merge only after https://github.com/argoproj/argo-cd/pull/8136 has been merged.

Referenced PR switches jwt-go library in Argo CD that fixes https://oss-fuzz.com/testcase-detail/5460437754314752

Signed-off-by: jannfis <jann@mistrust.net>