### PR TITLE
etcd: clean up grpc apis fuzzer

### DIFF
--- a/projects/etcd/v3_grpc_fuzzer.go
+++ b/projects/etcd/v3_grpc_fuzzer.go
@@ -154,6 +154,7 @@ func FuzzGRPCApis(data []byte) int {
 	}
 
 	// Create test cluster
+	defer cleanupDir()
 	clus, err := integration.NewClusterV3Fuzz(t2, &integration.ClusterConfig{Size: 3}, f)
 	if err != nil {
 		return 0


### PR DESCRIPTION
cleans up the created files at runtime.