### PR TITLE
argo: Avoid panic in helper function

### DIFF
--- a/projects/argo/artifacts_fuzzer.go
+++ b/projects/argo/artifacts_fuzzer.go
@@ -18,8 +18,17 @@ package artifacts
 import (
 	testhttp "github.com/stretchr/testify/http"
 	"net/http"
+	"net/url"
 	"strings"
 )
+
+func mustParseFuzz(text string) (*url.URL, error) {
+	u, err := url.Parse(text)
+	if err != nil {
+		return nil, err
+	}
+	return u, nil
+}
 
 func FuzzGetOutputArtifact(data []byte) int {
 	var url strings.Builder
@@ -27,7 +36,11 @@ func FuzzGetOutputArtifact(data []byte) int {
 	url.WriteString(string(data))
 	s := newServer()
 	r := &http.Request{}
-	r.URL = mustParse(url.String())
+	parsedUrl, err := mustParseFuzz(url.String())
+	if err != nil {
+		return 0
+	}
+	r.URL = parsedUrl
 	w := &testhttp.TestResponseWriter{}
 	s.GetOutputArtifact(w, r)
 	return 0
@@ -39,7 +52,11 @@ func FuzzGetOutputArtifactByUID(data []byte) int {
 	url.WriteString(string(data))
 	s := newServer()
 	r := &http.Request{}
-	r.URL = mustParse(url.String())
+	parsedUrl, err := mustParseFuzz(url.String())
+	if err != nil {
+		return 0
+	}
+	r.URL = parsedUrl
 	w := &testhttp.TestResponseWriter{}
 	s.GetInputArtifactByUID(w, r)
 	s.GetOutputArtifactByUID(w, r)


### PR DESCRIPTION
A panic in a helper function broke these two fuzzers. This PR allows the fuzzers to instead exit gracefully.