### PR TITLE
etcd: catch more cases in raft fuzzer

### DIFF
--- a/projects/etcd/build.sh
+++ b/projects/etcd/build.sh
@@ -7,6 +7,9 @@ set -x
 sed -i '/FORBIDDEN_DEPENDENCY/d' $SRC/etcd/server/go.mod
 sed -i '/FORBIDDEN_DEPENDENCY/d' $SRC/etcd/raft/go.mod
 
+# Change panic message so we can catch them:
+sed 's/panic(err)/panic("GOT A FUZZ ERROR")/g' -i $SRC/etcd/raft/raft.go
+
 
 mkdir $SRC/etcd/tests/fuzzing
 


### PR DESCRIPTION
1. Catch all `panic()`'s.
2. Implement a custom logger that panics a standardized message that can easily be caught.