### PR TITLE
cluster-api: Add reconciler fuzzer

### DIFF
--- a/projects/cluster-api/bootstrap_kubeadm_fuzzer.go
+++ b/projects/cluster-api/bootstrap_kubeadm_fuzzer.go
@@ -1,3 +1,18 @@
+// Copyright 2022 ADA Logics Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
 package utils
 
 import (

--- a/projects/cluster-api/cluster_controller_fuzzer.go
+++ b/projects/cluster-api/cluster_controller_fuzzer.go
@@ -1,0 +1,183 @@
+// Copyright 2022 ADA Logics Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package cluster
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	// +kubebuilder:scaffold:imports
+	. "github.com/onsi/gomega"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+
+	fuzz "github.com/AdaLogics/go-fuzz-headers"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/cluster-api/api/v1beta1/index"
+	"sigs.k8s.io/cluster-api/controllers/remote"
+	machinecontroller "sigs.k8s.io/cluster-api/internal/controllers/machine"
+	"sigs.k8s.io/cluster-api/internal/test/envtest"
+)
+
+const (
+	timeout                       = time.Second * 30
+	clusterReconcileNamespaceFuzz = "test-cluster-reconcile"
+)
+
+var (
+	env         *envtest.Environment
+	ctx         = ctrl.SetupSignalHandler()
+	fakeScheme  = runtime.NewScheme()
+	fuzzInitter sync.Once
+)
+
+// Checks whether the directory of a filename exists.
+// If it doesn't exists, then it is created.
+func createFile(fileNamePath, fileContents string) error {
+	path := filepath.Dir(fileNamePath)
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		err := os.MkdirAll(path, 0755)
+		if err != nil {
+			return err
+		}
+	}
+	f, err := os.Create(fileNamePath)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	_, err = f.WriteString(fileContents)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func createCrdFiles() {
+	crds := envtest.CrdMap
+
+	for k, v := range crds {
+		err := createFile(k, v)
+		if err != nil {
+			panic(err)
+		}
+	}
+}
+
+func fuzzInit() {
+	createCrdFiles()
+	_ = clientgoscheme.AddToScheme(fakeScheme)
+	_ = clusterv1.AddToScheme(fakeScheme)
+	_ = apiextensionsv1.AddToScheme(fakeScheme)
+	TestMain()
+}
+
+func TestMain() {
+	m := &testing.M{}
+	setupIndexes := func(ctx context.Context, mgr ctrl.Manager) {
+		if err := index.AddDefaultIndexes(ctx, mgr); err != nil {
+			panic(fmt.Sprintf("unable to setup index: %v", err))
+		}
+	}
+
+	setupReconcilers := func(ctx context.Context, mgr ctrl.Manager) {
+		// Set up a ClusterCacheTracker and ClusterCacheReconciler to provide to controllers
+		// requiring a connection to a remote cluster
+		log := ctrl.Log.WithName("remote").WithName("ClusterCacheTracker")
+		tracker, err := remote.NewClusterCacheTracker(
+			mgr,
+			remote.ClusterCacheTrackerOptions{
+				Log:     &log,
+				Indexes: remote.DefaultIndexes,
+			},
+		)
+		if err != nil {
+			panic(fmt.Sprintf("unable to create cluster cache tracker: %v", err))
+		}
+		if err := (&remote.ClusterCacheReconciler{
+			Client:  mgr.GetClient(),
+			Log:     ctrl.Log.WithName("remote").WithName("ClusterCacheReconciler"),
+			Tracker: tracker,
+		}).SetupWithManager(ctx, mgr, controller.Options{MaxConcurrentReconciles: 1}); err != nil {
+			panic(fmt.Sprintf("Failed to start ClusterCacheReconciler: %v", err))
+		}
+		if err := (&Reconciler{
+			Client:    mgr.GetClient(),
+			APIReader: mgr.GetClient(),
+		}).SetupWithManager(ctx, mgr, controller.Options{MaxConcurrentReconciles: 1}); err != nil {
+			panic(fmt.Sprintf("Failed to start ClusterReconciler: %v", err))
+		}
+		if err := (&machinecontroller.Reconciler{
+			Client:    mgr.GetClient(),
+			APIReader: mgr.GetAPIReader(),
+			Tracker:   tracker,
+		}).SetupWithManager(ctx, mgr, controller.Options{MaxConcurrentReconciles: 1}); err != nil {
+			panic(fmt.Sprintf("Failed to start MachineReconciler: %v", err))
+		}
+	}
+
+	SetDefaultEventuallyPollingInterval(100 * time.Millisecond)
+	SetDefaultEventuallyTimeout(timeout)
+
+	envtest.Run(ctx, envtest.RunInput{
+		M:                m,
+		SetupEnv:         func(e *envtest.Environment) { env = e },
+		SetupIndexes:     setupIndexes,
+		SetupReconcilers: setupReconcilers,
+	})
+}
+
+// This fuzzer does not run on OSS-fuzz because the kubebuilder
+// binaries are not available in the OSS-fuzz runtime environement.
+func FuzzClusterController(data []byte) int {
+	fuzzInitter.Do(fuzzInit)
+	f := fuzz.NewConsumer(data)
+	instance := &clusterv1.Cluster{}
+	err := f.GenerateStruct(instance)
+	if err != nil {
+		return 0
+	}
+
+	ns, err := env.CreateNamespace(ctx, clusterReconcileNamespaceFuzz)
+	if err != nil {
+		return 0
+	}
+	defer func() {
+		if err := env.Delete(ctx, ns); err != nil {
+			panic(err)
+		}
+	}()
+
+	err = env.Create(ctx, instance)
+	if err != nil {
+		return 0
+	}
+	defer func() {
+		err := env.Delete(ctx, instance)
+		if err != nil {
+			panic(err)
+		}
+	}()
+	return 1
+}

--- a/projects/cluster-api/crd-creation/main.go
+++ b/projects/cluster-api/crd-creation/main.go
@@ -1,0 +1,111 @@
+// Copyright 2022 ADA Logics Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func walkDir(dirPath string, fileMap map[string]string) error {
+	err := filepath.Walk(dirPath,
+		func(path string, info os.FileInfo, err error) error {
+			if err != nil {
+				return err
+			}
+			if !info.IsDir() {
+				dat, err := os.ReadFile(path)
+				if err != nil {
+					panic(err)
+				}
+				escapedString := strings.Replace(string(dat), "`", "", -1)
+				fileMap[path] = escapedString
+			}
+			return nil
+		})
+	return err
+}
+
+// Checks whether the directory of a filename exists.
+// If it doesn't exists, then it is created.
+func checkOrCreateDir(fileNamePath string) error {
+	path := filepath.Dir(fileNamePath)
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		err := os.MkdirAll(path, 0755)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func createFile(fileMap map[string]string) error {
+	var builder strings.Builder
+	builder.WriteString("package envtest\n\n")
+	builder.WriteString("var CrdMap = map[string]string{")
+
+	for k, v := range fileMap {
+		k2 := strings.Replace(k, "/src/cluster-api", ".", -1)
+		builder.WriteString("\"" + k2 + "\":`" + v + "`,\n")
+		//fmt.Println(filepath.Dir(k))
+	}
+	builder.WriteString("}\n")
+	f, err := os.Create("/src/cluster-api/internal/test/envtest/static_crds.go")
+	if err != nil {
+		panic(err)
+	}
+
+	defer f.Close()
+	_, err = f.WriteString(builder.String())
+	if err != nil {
+		panic(err)
+	}
+	return nil
+}
+
+func compareFileMaps(fileMap map[string]string) {
+	/*for k, v := range fileMap {
+		if crdMap[k] != fileMap[k] {
+			panic("they should be similar")
+		}
+	}*/
+}
+
+func main() {
+	dirPaths := []string{"/src/cluster-api/config/crd/bases",
+		"/src/cluster-api/controlplane/kubeadm/config/crd/bases",
+		"/src/cluster-api/bootstrap/kubeadm/config/crd/bases",
+		"/src/cluster-api/config/webhook",
+		"/src/cluster-api/bootstrap/kubeadm/config/webhook",
+		"/src/cluster-api/controlplane/kubeadm/config/webhook",
+	}
+
+	fileMap := make(map[string]string)
+	for _, dirPath := range dirPaths {
+		err := walkDir(dirPath, fileMap)
+		if err != nil {
+			panic(err)
+		}
+	}
+	err := createFile(fileMap)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println("Created static crds")
+
+}

--- a/projects/cluster-api/non-oss-fuzz/Dockerfile
+++ b/projects/cluster-api/non-oss-fuzz/Dockerfile
@@ -1,0 +1,13 @@
+FROM gcr.io/oss-fuzz-base/base-builder-go
+RUN git clone --depth 1 https://github.com/kubernetes-sigs/cluster-api
+RUN cd $SRC && go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
+RUN git clone --depth 1 --branch cluster-api https://github.com/AdamKorcz/cncf-fuzzing $SRC/cncf-fuzzing
+RUN mv $SRC/cncf-fuzzing/projects/cluster-api/non-oss-fuzz/build.sh $SRC/
+WORKDIR $SRC/cluster-api
+ENV FUZZING_LANGUAGE go
+ENV FUZZER fuzz_cluster_controller
+ENV FUZZ_TIME 600
+RUN compile
+RUN mkdir -p /usr/local/kubebuilder/bin
+CMD ["sh", "-c", "export KUBEBUILDER_BINARIES=$(setup-envtest use -p path) && mv ${KUBEBUILDER_BINARIES}/* /usr/local/kubebuilder/bin/ && /out/${FUZZER} -max_total_time=${FUZZ_TIME}"]
+

--- a/projects/cluster-api/non-oss-fuzz/build.sh
+++ b/projects/cluster-api/non-oss-fuzz/build.sh
@@ -1,0 +1,24 @@
+# Setup CRDs for the controller fuzzers
+cd $SRC/cncf-fuzzing/projects/cluster-api/crd-creation
+go mod init create-fuzz-env
+go mod tidy
+go run main.go
+
+cd $SRC/cluster-api
+sed -i 's/root := path.Join(path.Dir(filename), "..", "..", "..")/root := "."/g' $SRC/cluster-api/internal/test/envtest/environment.go
+sed -i '120 a code := 1' $SRC/cluster-api/internal/test/envtest/environment.go
+sed -i 's/code := input.M.Run()/return 1/g' $SRC/cluster-api/internal/test/envtest/environment.go
+sed -i 's/"path"/\/\/"path"/g' $SRC/cluster-api/internal/test/envtest/environment.go
+sed -i 's/_, filename, _, _/\/\/_, filename, _, _/g' $SRC/cluster-api/internal/test/envtest/environment.go
+#sed -i 's/err = kerrors.NewAggregate([]error{err, env.Stop()})/\/\/err = kerrors.NewAggregate([]error{err, env.Stop()})/g' $SRC/cluster-api/internal/test/envtest/environment.go
+
+sed -i 's/root := path.Join(path.Dir(filename), "..", "..", "..")/root := "."/g' $SRC/cluster-api/internal/test/envtest/webhooks.go
+sed -i 's/"path"/\/\/"path"/g' $SRC/cluster-api/internal/test/envtest/webhooks.go
+sed -i 's/_, filename, _, _/\/\/_, filename, _, _/g' $SRC/cluster-api/internal/test/envtest/webhooks.go
+sed -i 's/goruntime "runtime"/\/\/goruntime "runtime"/g' $SRC/cluster-api/internal/test/envtest/webhooks.go
+
+
+cp $SRC/cncf-fuzzing/projects/cluster-api/cluster_controller_fuzzer.go \
+   $SRC/cluster-api/internal/controllers/cluster/
+compile_go_fuzzer sigs.k8s.io/cluster-api/internal/controllers/cluster FuzzClusterController fuzz_cluster_controller
+exit 0

--- a/projects/cluster-api/non-oss-fuzz/run_fuzzer.sh
+++ b/projects/cluster-api/non-oss-fuzz/run_fuzzer.sh
@@ -1,0 +1,2 @@
+sudo docker build -t cluster_controller_fuzzer .
+sudo docker run cluster_controller_fuzzer


### PR DESCRIPTION
Adds a reconciler fuzzer that makes use of envtest. This is not supported by OSS-fuzz, so a separate Dockerfile is added to run the fuzzer locally.