### PR TITLE
cluster-api: Small fixes to fuzzers

### DIFF
--- a/projects/cluster-api/build.sh
+++ b/projects/cluster-api/build.sh
@@ -35,9 +35,10 @@ compile_go_fuzzer sigs.k8s.io/cluster-api/util/conditions FuzzPatchApply fuzz_pa
 
 cp $SRC/cncf-fuzzing/projects/cluster-api/topology_cluster_reconciler_fuzzer.go \
    $SRC/cluster-api/internal/controllers/topology/cluster/
-compile_go_fuzzer sigs.k8s.io/cluster-api/internal/controllers/topology/cluster FuzzreconcileMachineHealthCheck fuzz_reconcile_machine_health_check
-compile_go_fuzzer sigs.k8s.io/cluster-api/internal/controllers/topology/cluster FuzzreconcileControlPlane fuzz_reconcile_control_plane
-compile_go_fuzzer sigs.k8s.io/cluster-api/internal/controllers/topology/cluster FuzzreconcileReferencedObject fuzz_reconcile_referenced_object
+#compile_go_fuzzer sigs.k8s.io/cluster-api/internal/controllers/topology/cluster FuzzreconcileMachineHealthCheck fuzz_reconcile_machine_health_check
+#compile_go_fuzzer sigs.k8s.io/cluster-api/internal/controllers/topology/cluster FuzzreconcileControlPlane fuzz_reconcile_control_plane
+#compile_go_fuzzer sigs.k8s.io/cluster-api/internal/controllers/topology/cluster FuzzreconcileReferencedObject fuzz_reconcile_referenced_object
+compile_go_fuzzer sigs.k8s.io/cluster-api/internal/controllers/topology/cluster FuzzClusterReconcile fuzz_cluster_reconcile
 
 mkdir $SRC/cluster-api/fuzz
 cp $SRC/cncf-fuzzing/projects/cluster-api/conversion_fuzzer2.go \


### PR DESCRIPTION
1. Replace contexts with `context.Background()`
2. Add `Blueprint` validation
3. Add a fuzzer for the exported `Reconcile()` and deactivate the 3 fuzzers for the non-exported APIs. This is experiemental.