### PR TITLE
fix missing case (68 -> 69), fix sign-off issue

### DIFF
--- a/projects/vitess/vtctl_fuzzer.go
+++ b/projects/vitess/vtctl_fuzzer.go
@@ -176,7 +176,7 @@ func Fuzz(data []byte) int {
 		to := i + chunkSize //upper
 
 		// Index of command in getCommandType():
-		commandIndex := int(commandPart[command]) % 68
+		commandIndex := int(commandPart[command]) % 69
 		vtCommand := getCommandType(commandIndex)
 		commandSlice := []string{vtCommand}
 		args := strings.Split(string(restOfArray[from:to]), " ")


### PR DESCRIPTION
In `cncf-fuzzing/projects/vitess/vtctl_fuzzer.go`, the function `getCommandType` contains 69 cases ([0, 68]). However, the fuzzer always miss the case 68 since it mods to 68. I fixed it to 69.

Signed-off-by: happy-qop <all.u.ever.know@gmail.com>