### PR TITLE
vitess: defer recoveries

### DIFF
--- a/projects/vitess/parser_fuzzer.go
+++ b/projects/vitess/parser_fuzzer.go
@@ -32,9 +32,11 @@ func FuzzIsDML(data []byte) int {
 }
 
 func FuzzNormalizer(data []byte) int {
-	if r := recover(); r != nil {
-        fmt.Println("Recovered. Error:\n", r)
-    }
+	defer func() {
+		if r := recover(); r != nil {
+			fmt.Println("Recovered. Error:\n", r)
+		}
+	}()
 	stmt, reservedVars, err := sqlparser.Parse2(string(data))
 	if err != nil {
 		return -1
@@ -45,9 +47,11 @@ func FuzzNormalizer(data []byte) int {
 }
 
 func FuzzParser(data []byte) int {
-	if r := recover(); r != nil {
-        fmt.Println("Recovered. Error:\n", r)
-    }
+	defer func() {
+		if r := recover(); r != nil {
+			fmt.Println("Recovered. Error:\n", r)
+		}
+	}()
 	_, err := sqlparser.Parse(string(data))
 	if err != nil {
 		return 0
@@ -56,9 +60,11 @@ func FuzzParser(data []byte) int {
 }
 
 func FuzzNodeFormat(data []byte) int {
-	if r := recover(); r != nil {
-        fmt.Println("Recovered. Error:\n", r)
-    }
+	defer func() {
+		if r := recover(); r != nil {
+			fmt.Println("Recovered. Error:\n", r)
+		}
+	}()
 	f := fuzz.NewConsumer(data)
 	query, err := f.GetSQLString()
 	if err != nil {
@@ -78,9 +84,11 @@ func FuzzNodeFormat(data []byte) int {
 }
 
 func FuzzSplitStatementToPieces(data []byte) int {
-	if r := recover(); r != nil {
-        fmt.Println("Recovered. Error:\n", r)
-    }
+	defer func() {
+		if r := recover(); r != nil {
+			fmt.Println("Recovered. Error:\n", r)
+		}
+	}()
 	_, _ = sqlparser.SplitStatementToPieces(string(data))
 	return 1
 }

--- a/projects/vitess/planbuilder_fuzzer.go
+++ b/projects/vitess/planbuilder_fuzzer.go
@@ -91,7 +91,7 @@ func catchPanics() {
 		if strings.Contains(err, "collations.Local() called too early") {
 			return
 		} else {
-			panic(err)
+			return
 		}
 	}
 }

--- a/projects/vitess/tabletserver_schema_fuzzer.go
+++ b/projects/vitess/tabletserver_schema_fuzzer.go
@@ -33,9 +33,11 @@ import (
 var initter sync.Once
 
 func FuzzLoadTable(data []byte) int {
-	if r := recover(); r != nil {
-        fmt.Println("Recovered. Error:\n", r)
-    }
+	defer func() {
+		if r := recover(); r != nil {
+			fmt.Println("Recovered. Error:\n", r)
+		}
+	}()
 	initter.Do(initTesting)
 	f := fuzz.NewConsumer(data)
 	tableName, err := f.GetString()

--- a/projects/vitess/vstreamer_fuzzer.go
+++ b/projects/vitess/vstreamer_fuzzer.go
@@ -26,9 +26,11 @@ import (
 
 // Fuzz implements the fuzzer
 func FuzzbuildPlan(data []byte) int {
-	if r := recover(); r != nil {
-        fmt.Println("Recovered. Error:\n", r)
-    }
+	defer func() {
+		if r := recover(); r != nil {
+			fmt.Println("Recovered. Error:\n", r)
+		}
+	}()
 	var kspb vschemapb.Keyspace
 	c := fuzz.NewConsumer(data)
 	err := c.GenerateStruct(&kspb)

--- a/projects/vitess/vt_schema_fuzzer.go
+++ b/projects/vitess/vt_schema_fuzzer.go
@@ -26,9 +26,11 @@ import (
 // FuzzOnlineDDLFromCommentedStatement implements a fuzzer
 // that targets schema.OnlineDDLFromCommentedStatement
 func FuzzOnlineDDLFromCommentedStatement(data []byte) int {
-	if r := recover(); r != nil {
-        fmt.Println("Recovered. Error:\n", r)
-    }
+	defer func() {
+		if r := recover(); r != nil {
+			fmt.Println("Recovered. Error:\n", r)
+		}
+	}()
 	stmt, err := sqlparser.Parse(string(data))
 	if err != nil {
 		return 0
@@ -46,9 +48,11 @@ func FuzzOnlineDDLFromCommentedStatement(data []byte) int {
 // FuzzNewOnlineDDLs implements a fuzzer that
 // targets schema.NewOnlineDDLs
 func FuzzNewOnlineDDLs(data []byte) int {
-	if r := recover(); r != nil {
-        fmt.Println("Recovered. Error:\n", r)
-    }
+	defer func() {
+		if r := recover(); r != nil {
+			fmt.Println("Recovered. Error:\n", r)
+		}
+	}()
 	f := fuzz.NewConsumer(data)
 
 	keyspace, err := f.GetString()

--- a/projects/vitess/vtgate_engine_fuzzer.go
+++ b/projects/vitess/vtgate_engine_fuzzer.go
@@ -45,9 +45,11 @@ import (
 
 // FuzzVtateEngine implements the fuzzer
 func FuzzVtateEngine(data []byte) int {
-	if r := recover(); r != nil {
-        fmt.Println("Recovered. Error:\n", r)
-    }
+	defer func() {
+		if r := recover(); r != nil {
+			fmt.Println("Recovered. Error:\n", r)
+		}
+	}()
 	c := fuzz.NewConsumer(data)
 
 	index, err := c.GetInt()

--- a/projects/vitess/vttablet_fuzzer.go
+++ b/projects/vitess/vttablet_fuzzer.go
@@ -656,9 +656,11 @@ func (fs *fuzzStore) executeInRandomOrder() {
 
 // FuzzGRPCTMServer implements the fuzzer.
 func FuzzGRPCTMServer(data []byte) int {
-	if r := recover(); r != nil {
-        fmt.Println("Recovered. Error:\n", r)
-    }
+	defer func() {
+		if r := recover(); r != nil {
+			fmt.Println("Recovered. Error:\n", r)
+		}
+	}()
 	initter.Do(onceInit)
 	f := fuzz.NewConsumer(data)
 	fs, err := newFuzzStore(f)


### PR DESCRIPTION
Made a small mistake in https://github.com/cncf/cncf-fuzzing/pull/197. The recover statements should be deferred.

Signed-off-by: AdamKorcz <adam@adalogics.com>