### PR TITLE
Cilium: Attempt to fix broken coverage build

### DIFF
--- a/projects/cilium/OnData_fuzzer.go
+++ b/projects/cilium/OnData_fuzzer.go
@@ -147,8 +147,8 @@ func verifyParserData(parser string, d [][]byte, reply bool) error {
 	return nil
 }
 
-// FuzzParsers implements the fuzzer
-func FuzzParsers(data []byte) int {
+// FuzzMultipleParsers implements the fuzzer
+func FuzzMultipleParsers(data []byte) int {
 	f := fuzz.NewConsumer(data)
 
 	version, policies, d, reply, parser, err := createData(f)

--- a/projects/cilium/build.sh
+++ b/projects/cilium/build.sh
@@ -21,5 +21,5 @@ compile_go_fuzzer github.com/cilium/cilium/pkg/fqdn/matchpattern FuzzMatchpatter
 compile_go_fuzzer github.com/cilium/cilium/pkg/fqdn/matchpattern FuzzMatchpatternValidateWithoutCache fuzz_matchpattern_validate_without_cache
 compile_go_fuzzer github.com/cilium/cilium/pkg/hubble/parser FuzzParserDecode fuzz_parser_decode
 compile_go_fuzzer github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/labels FuzzLabelsParse fuzz_labels_parse
-compile_go_fuzzer github.com/cilium/cilium/proxylib/cassandra FuzzParsers fuzz_parsers
+compile_go_fuzzer github.com/cilium/cilium/proxylib/cassandra FuzzMultipleParsers fuzz_multiple_parsers
 


### PR DESCRIPTION
The Cilium coverage build is failing because the corpus for the `fuzz_parsers` fuzzer cannot be found. This PR renames it in an attempt to fix the issue.
Signed-off-by: AdamKorcz <adam@adalogics.com>