### PR TITLE
Cluster API: Fix assignment build errors for fuzzers

### DIFF
--- a/projects/cluster-api/conditions_fuzzer.go
+++ b/projects/cluster-api/conditions_fuzzer.go
@@ -44,8 +44,10 @@ func FuzzPatchApply(data []byte) int {
 	if err != nil {
 		return 0
 	}
-
-	patch := NewPatch(getterBefore, getterAfter)
+	patch, err := NewPatch(getterBefore, getterAfter)
+	if err != nil {
+		return 0
+	}
 	_ = patch.Apply(setter, options...)
 	return 1
 }

--- a/projects/cluster-api/patch_fuzzer.go
+++ b/projects/cluster-api/patch_fuzzer.go
@@ -77,7 +77,7 @@ func FuzzPatch(data []byte) int {
 	if err != nil {
 		return 0
 	}
-	_, err = patcher.Patch(fuzzCtx, obj)
+	_ = patcher.Patch(fuzzCtx, obj)
 	if err != nil {
 		return 0
 	}


### PR DESCRIPTION
Signed-off-by: killianmuldoon <kmuldoon@vmware.com>

Fix assignment errors - one of them introduced by my previous PR in #205 - to allow Cluster API fuzzers to build.

 