### PR TITLE
distribution: remove fuzzing for deprecated reference formats

### DIFF
--- a/projects/distribution/reference_fuzzer2.go
+++ b/projects/distribution/reference_fuzzer2.go
@@ -15,10 +15,7 @@
 
 package reference
 
-import (
-	"github.com/distribution/distribution/v3/digestset"
-	fuzz "github.com/AdaLogics/go-fuzz-headers"
-)
+import fuzz "github.com/AdaLogics/go-fuzz-headers"
 
 func FuzzWithNameAndWithTag(data []byte) int {
 	f := fuzz.NewConsumer(data)
@@ -51,16 +48,5 @@ func FuzzAllNormalizeApis(data []byte) int {
 		return 0
 	}
 	_, _ = ParseAnyReference(ref)
-	ds := &digestset.Set{}
-	err = f.GenerateStruct(ds)
-	if err != nil {
-		return 0
-	}
-	ref, err = f.GetString()
-	if err != nil {
-		return 0
-	}
-	_, _ = ParseAnyReferenceWithSet(ref, ds)
 	return 1
 }
-


### PR DESCRIPTION
- relates to https://github.com/distribution/distribution/pull/3774

The "shortid" format, as implemented in the ParseAnyReferenceWithSet() function has been deprecated, and will be removed from the distribution repository.
