### PR TITLE
cilium: bring back bpf fuzzer

### DIFF
--- a/projects/cilium/bpf_fuzzer.go
+++ b/projects/cilium/bpf_fuzzer.go
@@ -1,0 +1,68 @@
+// Copyright 2022 ADA Logics Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package bpf
+
+import (
+	"github.com/cilium/ebpf"
+	fuzz "github.com/AdaLogics/go-fuzz-headers"
+	"os"
+)
+
+var (
+	bpffsPath = "bpffFile"
+	elfPath   = "elfFile"
+	targets   = map[int]string{
+		0: "StartBPFFSMigration",
+		1: "FinalizeBPFFSMigration",
+	}
+)
+
+func FuzzBpf(data []byte) int {
+	f := fuzz.NewConsumer(data)
+	bpffsData, err := f.GetBytes()
+	if err != nil {
+		return 0
+	}
+
+	coll := &ebpf.CollectionSpec{}
+	f.GenerateStruct(coll)
+
+	target, err := f.GetInt()
+	if err != nil {
+		return 0
+	}
+
+	// bpff File
+	bpffFile, err := os.Create(bpffsPath)
+	if err != nil {
+		os.Remove(bpffsPath)
+		return 0
+	}
+	defer bpffFile.Close()
+	defer os.Remove(bpffsPath)
+	bpffFile.Write(bpffsData)
+	switch targets[target%len(targets)] {
+	case "StartBPFFSMigration":
+		StartBPFFSMigration(bpffsPath, coll)
+	case "FinalizeBPFFSMigration":
+		revert, err := f.GetBool()
+		if err != nil {
+			return 0
+		}
+		FinalizeBPFFSMigration(bpffsPath, coll, revert)
+	}
+	return 1
+}

--- a/projects/cilium/build.sh
+++ b/projects/cilium/build.sh
@@ -1,17 +1,18 @@
 # install Go 1.19
 apt-get update && apt-get install -y wget
 cd $SRC
-wget https://go.dev/dl/go1.19.linux-amd64.tar.gz
+wget https://go.dev/dl/go1.19.4.linux-amd64.tar.gz
 
 mkdir temp-go
 rm -rf /root/.go/*
-tar -C temp-go/ -xzf go1.19.linux-amd64.tar.gz
+tar -C temp-go/ -xzf go1.19.4.linux-amd64.tar.gz
 mv temp-go/go/* /root/.go/
 cd $SRC/cilium
 
 export CILIUM=$SRC/cncf-fuzzing/projects/cilium
 
 cp $CILIUM/elf_fuzzer.go $SRC/cilium/pkg/elf/
+cp $CILIUM/bpf_fuzzer.go $SRC/cilium/pkg/bpf/
 cp $CILIUM/matchpattern_fuzzer.go $SRC/cilium/pkg/fqdn/matchpattern/
 cp $CILIUM/hubble_parser_fuzzer.go $SRC/cilium/pkg/hubble/parser/
 cp $CILIUM/labels_fuzzer.go $SRC/cilium/pkg/k8s/slim/k8s/apis/labels/
@@ -33,6 +34,7 @@ compile_go_fuzzer github.com/cilium/cilium/pkg/monitor/format FuzzFormatEvent fu
 compile_go_fuzzer github.com/cilium/cilium/pkg/monitor/payload FuzzPayloadEncodeDecode FuzzPayloadEncodeDecode
 compile_go_fuzzer github.com/cilium/cilium/pkg/elf FuzzElfOpen fuzz_elf_open
 compile_go_fuzzer github.com/cilium/cilium/pkg/elf FuzzElfWrite fuzz_elf_write
+compile_go_fuzzer github.com/cilium/cilium/pkg/bpf FuzzBpf fuzz_bpf
 compile_go_fuzzer github.com/cilium/cilium/pkg/fqdn/matchpattern FuzzMatchpatternValidate fuzz_matchpattern_validate
 compile_go_fuzzer github.com/cilium/cilium/pkg/fqdn/matchpattern FuzzMatchpatternValidateWithoutCache fuzz_matchpattern_validate_without_cache
 compile_go_fuzzer github.com/cilium/cilium/pkg/hubble/parser FuzzParserDecode fuzz_parser_decode


### PR DESCRIPTION
The fuzzer was removed here as a quick fix for the broken build: https://github.com/cncf/cncf-fuzzing/pull/228. This PR brings it back.

Signed-off-by: AdamKorcz <adam@adalogics.com>