### PR TITLE
vitess: fix build

### DIFF
--- a/projects/vitess/abstract_fuzzer.go
+++ b/projects/vitess/abstract_fuzzer.go
@@ -13,10 +13,11 @@
 // limitations under the License.
 //
 
-package abstract
+package operators
 
 import (
 	"vitess.io/vitess/go/vt/sqlparser"
+	"vitess.io/vitess/go/vt/vtgate/planbuilder/plancontext"
 	"vitess.io/vitess/go/vt/vtgate/semantics"
 
 	fuzz "github.com/AdaLogics/go-fuzz-headers"
@@ -39,7 +40,8 @@ func FuzzAnalyse(data []byte) int {
 		if err != nil {
 			return 0
 		}
-		_, _ = createOperatorFromSelect(stmt, semTable)
+		ctx := plancontext.NewPlanningContext(nil, semTable, nil, 0)
+		_, _ = createOperatorFromSelect(ctx, semTable)
 
 	default:
 		return 0

--- a/projects/vitess/build.sh
+++ b/projects/vitess/build.sh
@@ -58,14 +58,14 @@ rm $SRC/vitess/go/vt/vtgate/vindexes/fuzz.go
 rm $SRC/vitess/go/vt/vtgate/planbuilder/fuzz.go
 rm $SRC/vitess/go/vt/vttablet/tabletmanager/vreplication/fuzz.go
 rm $SRC/vitess/go/vt/vtgate/engine/fuzz.go
-rm $SRC/vitess/go/vt/vtgate/planbuilder/abstract/fuzz.go
+rm $SRC/vitess/go/vt/vtgate/planbuilder/operators/fuzz.go
 rm $SRC/vitess/go/vt/vtgate/grpcvtgateconn/fuzz_flaky_test.go
 rm $SRC/vitess/go/vt/vttablet/tabletserver/fuzz.go
 
 mv $SRC/cncf-fuzzing/projects/vitess/mysql_fuzzer.go $SRC/vitess/go/mysql/
 
 mv $SRC/cncf-fuzzing/projects/vitess/grpcvtgateconn_fuzzer.go $SRC/vitess/go/vt/vtgate/grpcvtgateconn/
-mv $SRC/cncf-fuzzing/projects/vitess/abstract_fuzzer.go $SRC/vitess/go/vt/vtgate/planbuilder/abstract/
+mv $SRC/cncf-fuzzing/projects/vitess/abstract_fuzzer.go $SRC/vitess/go/vt/vtgate/planbuilder/operators/
 
 # collation fuzzer
 mv ./go/mysql/collations/uca_test.go \
@@ -134,7 +134,7 @@ compile_go_fuzzer vitess.io/vitess/go/vt/vttablet/tabletserver FuzzGetPlan fuzz_
 compile_go_fuzzer vitess.io/vitess/go/vt/vtgate/grpcvtgateconn FuzzGrpcvtgateconn grpc_vtgate_fuzzer
 
 
-compile_go_fuzzer vitess.io/vitess/go/vt/vtgate/planbuilder/abstract FuzzAnalyse fuzz_analyse gofuzz
+compile_go_fuzzer vitess.io/vitess/go/vt/vtgate/planbuilder/operators FuzzAnalyse fuzz_analyse gofuzz
 
 
 

--- a/projects/vitess/mysql_fuzzer.go
+++ b/projects/vitess/mysql_fuzzer.go
@@ -330,7 +330,7 @@ func FuzzTLSServer(data []byte) int {
 		Password: "password1",
 	}}
 	defer authServer.close()
-	l, err := NewListener("tcp", "127.0.0.1:", authServer, th, 0, 0, false)
+	l, err := NewListener("tcp", "127.0.0.1:", authServer, th, 0, 0, false, false)
 	if err != nil {
 		return -1
 	}


### PR DESCRIPTION
`abstract/fuzz.go` has been moved to `operators/fuzz.go`