### PR TITLE
knative: add experimental roundtrip fuzzer based on go-fuzz-headers

### DIFF
--- a/projects/knative/build.sh
+++ b/projects/knative/build.sh
@@ -63,3 +63,11 @@ printf "package v1\nimport _ \"github.com/AdamKorcz/go-118-fuzz-build/testing\"\
 go mod tidy && go mod vendor
 mv $SRC/eventing/pkg/apis/messaging/v1/roundtrip_test.go $SRC/eventing/pkg/apis/messaging/v1/roundtrip_test_fuzz.go
 compile_native_go_fuzzer knative.dev/eventing/pkg/apis/messaging/v1 FuzzMessagingRoundTripTypesToJSON FuzzMessagingRoundTripTypesToJSON
+
+# build experimental messaging fuzzer
+rm $SRC/eventing/pkg/apis/messaging/v1/fuzz_messaging_v1.go
+
+cp $CNCFFuzzing/fuzz_messaging_v1_experimental.go $SRC/eventing/pkg/apis/messaging/v1/
+cp $CNCFFuzzing/fuzzer_funcs.go $SRC/eventing/pkg/apis/messaging/v1/
+go mod tidy && go mod vendor
+compile_native_go_fuzzer knative.dev/eventing/pkg/apis/messaging/v1 FuzzMessagingRoundTripTypesToJSONExperimental FuzzMessagingRoundTripTypesToJSONExperimental

--- a/projects/knative/fuzz_messaging_v1_experimental.go
+++ b/projects/knative/fuzz_messaging_v1_experimental.go
@@ -1,0 +1,37 @@
+// Copyright 2023 the cncf-fuzzing authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package v1
+
+import (
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"github.com/AdamKorcz/kubefuzzing/pkg/roundtrip"
+)
+
+
+
+func init() {
+	utilruntime.Must(AddToScheme(roundtrip.Scheme))
+	roundtrip.AddFuncs(fuzzerFuncsGfh())
+	roundtrip.AddFuncs(roundtrip.GenericFuzzerFuncs())
+	roundtrip.AddFuncs(roundtrip.V1FuzzerFuncs())
+	roundtrip.AddFuncs(roundtrip.V1beta1FuzzerFuncs())
+}
+
+func FuzzMessagingRoundTripTypesToJSONExperimental(f *testing.F) {
+	f.Fuzz(func(t *testing.T, data []byte, typeToTest int) {
+		roundtrip.ExternalTypesViaJSON(data, typeToTest)
+	})
+}

--- a/projects/knative/fuzzer_funcs.go
+++ b/projects/knative/fuzzer_funcs.go
@@ -1,0 +1,61 @@
+// Copyright 2023 the cncf-fuzzing authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package v1
+
+import (
+	"knative.dev/eventing/pkg/apis/messaging"
+
+	gfh "github.com/AdaLogics/go-fuzz-headers"
+)
+
+func fuzzerFuncsGfh() []interface{} {
+	return []interface{}{
+		func(ch *Channel, c gfh.Continue) error {
+			c.F.GenerateWithCustom(ch)
+			if ch != nil {
+				if ch.Annotations == nil {
+					ch.Annotations = make(map[string]string)
+				}
+				ch.Annotations[messaging.SubscribableDuckVersionAnnotation] = "v1"
+			}
+			ch.Status.SetConditions(nil)
+
+			ch.Status.InitializeConditions()
+			return nil
+		},
+		func(imc *InMemoryChannel, c gfh.Continue) error {
+			c.F.GenerateWithCustom(imc)
+			if imc != nil {
+				if imc.Annotations == nil {
+					imc.Annotations = make(map[string]string)
+				}
+				imc.Annotations[messaging.SubscribableDuckVersionAnnotation] = "v1"
+			}
+			imc.Status.SetConditions(nil)
+
+			imc.Status.InitializeConditions()
+			return nil
+		},
+		func(s *SubscriptionStatus, c gfh.Continue) error {
+			c.F.GenerateWithCustom(s)
+
+			s.Status.SetConditions(nil)
+
+			s.InitializeConditions()
+			return nil
+		},
+	}
+}


### PR DESCRIPTION
Adds a roundtrip test based on go-fuzz-headers. Also adds a file with upstream k8s functions for the types used in the knative fuzzer.

Signed-off-by: AdamKorcz <adam@adalogics.com>