### PR TITLE
Fix distribution

### DIFF
--- a/projects/distribution/build.sh
+++ b/projects/distribution/build.sh
@@ -72,7 +72,6 @@ zip $OUT/parser_fuzzer_seed_corpus.zip $CNCFPATH/corpus/parserFuzzer/*
 rm -r ./vendor
 
 # Used to build native fuzzers
-go get github.com/AdamKorcz/go-118-fuzz-build/utils
 go get github.com/AdaLogics/go-fuzz-headers
 #compile_native_go_fuzzer $DISTRIBUTION/reference FuzzParseNormalizedNamedNative fuzz_parse_normalized_name_native
 rm $SRC/distribution/reference/native_reference_fuzzer.go

--- a/projects/distribution/build.sh
+++ b/projects/distribution/build.sh
@@ -80,8 +80,6 @@ rm $SRC/distribution/reference/native_reference_fuzzer.go
 go mod edit -dropreplace google.golang.org/grpc
 go mod download && go mod tidy
 
-$SRC/distribution/script/oss_fuzz_build.sh
-
 compile_go_fuzzer $DISTRIBUTION/reference FuzzParseNormalizedNamed fuzz_parse_normalized_named
 
 # Target(s) that break coverage build

--- a/projects/distribution/build.sh
+++ b/projects/distribution/build.sh
@@ -79,8 +79,6 @@ rm $SRC/distribution/reference/native_reference_fuzzer.go
 go mod edit -dropreplace google.golang.org/grpc
 go mod download && go mod tidy
 
-compile_go_fuzzer $DISTRIBUTION/reference FuzzParseNormalizedNamed fuzz_parse_normalized_named
-
 # Target(s) that break coverage build
 if [ "$SANITIZER" != "coverage" ]
 then

--- a/projects/distribution/build.sh
+++ b/projects/distribution/build.sh
@@ -6,11 +6,11 @@ set -x
 
 apt-get update && apt-get install -y wget
 cd $SRC
-wget https://go.dev/dl/go1.18.2.linux-amd64.tar.gz
+wget https://go.dev/dl/go1.19.4.linux-amd64.tar.gz
 
 mkdir temp-go
 rm -rf /root/.go/*
-tar -C temp-go/ -xzf go1.18.2.linux-amd64.tar.gz
+tar -C temp-go/ -xzf go1.19.4.linux-amd64.tar.gz
 mv temp-go/go/* /root/.go/
 cd $SRC/distribution
 

--- a/projects/distribution/registry_proxy_fuzzer.go
+++ b/projects/distribution/registry_proxy_fuzzer.go
@@ -152,7 +152,7 @@ func newManifestStoreTestEnvFuzz(f *fuzz.ConsumeFuzzer, name, tag string) (*mani
 
 	ctx := context.Background()
 	truthRegistry, err := storage.NewRegistry(ctx, inmemory.New(),
-		storage.BlobDescriptorCacheProvider(memory.NewInMemoryBlobDescriptorCacheProvider()),
+		storage.BlobDescriptorCacheProvider(memory.NewInMemoryBlobDescriptorCacheProvider(memory.UnlimitedSize)),
 		storage.Schema1SigningKey(k),
 		storage.EnableSchema1)
 	if err != nil {
@@ -176,7 +176,7 @@ func newManifestStoreTestEnvFuzz(f *fuzz.ConsumeFuzzer, name, tag string) (*mani
 		return nil, err
 	}
 
-	localRegistry, err := storage.NewRegistry(ctx, inmemory.New(), storage.BlobDescriptorCacheProvider(memory.NewInMemoryBlobDescriptorCacheProvider()), storage.EnableRedirect, storage.DisableDigestResumption, storage.Schema1SigningKey(k), storage.EnableSchema1)
+	localRegistry, err := storage.NewRegistry(ctx, inmemory.New(), storage.BlobDescriptorCacheProvider(memory.NewInMemoryBlobDescriptorCacheProvider(memory.UnlimitedSize)), storage.EnableRedirect, storage.DisableDigestResumption, storage.Schema1SigningKey(k), storage.EnableSchema1)
 	if err != nil {
 		return nil, err
 	}

--- a/projects/distribution/storage_fuzzer.go
+++ b/projects/distribution/storage_fuzzer.go
@@ -158,7 +158,7 @@ func FuzzBlob(data []byte) int {
 	ctx := context.Background()
 	imageName, _ := reference.WithName("foo/bar")
 	driver := testdriver.New()
-	registry, err := NewRegistry(ctx, driver, BlobDescriptorCacheProvider(memory.NewInMemoryBlobDescriptorCacheProvider()), EnableDelete, EnableRedirect)
+	registry, err := NewRegistry(ctx, driver, BlobDescriptorCacheProvider(memory.NewInMemoryBlobDescriptorCacheProvider(memory.UnlimitedSize)), EnableDelete, EnableRedirect)
 	if err != nil {
 		return 0
 	}


### PR DESCRIPTION
This PR removes deleted scripts and adjusts calls to `memory.NewInMemoryBlobDescriptorCacheProvider`, which now expects an integer argument.