### PR TITLE
etcd: fix raft import and fuzzer

### DIFF
--- a/projects/etcd/build.sh
+++ b/projects/etcd/build.sh
@@ -122,13 +122,13 @@ compile_go_fuzzer go.etcd.io/etcd/server/v3/etcdserver/api/rafthttp FuzzRaftHttp
 compile_go_fuzzer go.etcd.io/etcd/server/v3/etcdserver/api/rafthttp FuzzMessageEncodeDecode fuzz_message_encode_decode
 
 # raft fuzzer
-cd $SRC/etcd/raft
+cd $SRC/raft
 mv $SRC/cncf-fuzzing/projects/etcd/raft_fuzzer.go ./
 go mod tidy
 mv diff_test.go diff_test_fuzz.go
 mv log_test.go log_test_fuzz.go
 mv raft_test.go raft_test_fuzz.go
-compile_go_fuzzer go.etcd.io/etcd/raft/v3 FuzzStep fuzz_step
+compile_go_fuzzer go.etcd.io/raft/v3 FuzzStep fuzz_step
 
 # file_purge_fuzzer
 cd $SRC/etcd/client/pkg/fileutil

--- a/projects/etcd/raft_api_fuzzer.go
+++ b/projects/etcd/raft_api_fuzzer.go
@@ -22,7 +22,7 @@ import (
 
 	"go.etcd.io/etcd/api/v3/version"
 	"go.etcd.io/etcd/client/pkg/v3/types"
-	"go.etcd.io/etcd/raft/v3/raftpb"
+	"go.etcd.io/raft/v3/raftpb"
 	"go.uber.org/zap"
 
 	fuzz "github.com/AdaLogics/go-fuzz-headers"


### PR DESCRIPTION
This fixes an import in etcd fuzzers and the raft fuzzer. When this PR is merged, the corresponding PR in OSS-Fuzz (https://github.com/google/oss-fuzz/pull/9374) should be also merged.