### PR TITLE
notary: use fork of go-fuzz-headers

### DIFF
--- a/projects/notary/build.sh
+++ b/projects/notary/build.sh
@@ -5,6 +5,7 @@ export CNCFFuzz="${SRC}/cncf-fuzzing/projects/notary"
 cp $CNCFFuzz/fuzz_trustmanager_test.go $SRC/notary/trustmanager/
 
 printf "package trustmanager\nimport _ \"github.com/AdamKorcz/go-118-fuzz-build/testing\"\n" > $SRC/notary/trustmanager/registerfuzzdep.go
+go mod edit -replace github.com/AdaLogics/go-fuzz-headers=github.com/AdamKorcz/go-fuzz-headers-1@1f10f66a31bf0e5cc26a2f4a74bd3be5f6463b67
 go mod tidy && go mod vendor
 compile_go_fuzzer github.com/theupdateframework/notary/cryptoservice/fuzz Fuzz fuzz
 
@@ -19,5 +20,6 @@ compile_native_go_fuzzer github.com/theupdateframework/notary/server/handlers Fu
 cd $SRC/notation-go
 mv "${SRC}/cncf-fuzzing/projects/notary/fuzz_verification.go" $SRC/notation-go/verifier/
 printf "package verifier\nimport _ \"github.com/AdamKorcz/go-118-fuzz-build/testing\"\n" > verifier/registerfuzzdep.go
+go mod edit -replace github.com/AdaLogics/go-fuzz-headers=github.com/AdamKorcz/go-fuzz-headers-1@1f10f66a31bf0e5cc26a2f4a74bd3be5f6463b67
 go mod tidy
 compile_native_go_fuzzer github.com/notaryproject/notation-go/verifier FuzzVerify FuzzVerify


### PR DESCRIPTION
My fork currently has some fixes that won't be merged just yet. Switching to the fork temporarily.

Signed-off-by: AdamKorcz <adam@adalogics.com>