### PR TITLE
notary: add fuzzer

### DIFF
--- a/projects/notary/build.sh
+++ b/projects/notary/build.sh
@@ -3,6 +3,7 @@ sed 's/go 1.17/go 1.19/g' -i $SRC/notary/go.mod
 export CNCFFuzz="${SRC}/cncf-fuzzing/projects/notary"
 
 cp $CNCFFuzz/fuzz_trustmanager_test.go $SRC/notary/trustmanager/
+cp $CNCFFuzz/fuzz_tuf_utils.go $SRC/notary/tuf/utils/
 
 printf "package trustmanager\nimport _ \"github.com/AdamKorcz/go-118-fuzz-build/testing\"\n" > $SRC/notary/trustmanager/registerfuzzdep.go
 go mod edit -replace github.com/AdaLogics/go-fuzz-headers=github.com/AdamKorcz/go-fuzz-headers-1@1f10f66a31bf0e5cc26a2f4a74bd3be5f6463b67
@@ -13,6 +14,7 @@ mv $SRC/notary/trustmanager/keys_test.go $SRC/notary/trustmanager/keys_test_fuzz
 mv $SRC/notary/trustmanager/keystore_test.go $SRC/notary/trustmanager/keystore_test_fuzz.go
 compile_native_go_fuzzer github.com/theupdateframework/notary/trustmanager FuzzImportKeysSimple FuzzImportKeysSimple
 compile_native_go_fuzzer github.com/theupdateframework/notary/trustmanager FuzzImportKeysStructured FuzzImportKeysStructured
+compile_native_go_fuzzer github.com/theupdateframework/notary/tuf/utils FuzzParsePEMPrivateKey FuzzParsePEMPrivateKey
 
 mv $SRC/cncf-fuzzing/projects/notary/fuzz_handlers.go $SRC/notary/server/handlers/
 compile_native_go_fuzzer github.com/theupdateframework/notary/server/handlers FuzzAtomicUpdateHandler FuzzAtomicUpdateHandler

--- a/projects/notary/fuzz_tuf_utils.go
+++ b/projects/notary/fuzz_tuf_utils.go
@@ -1,0 +1,26 @@
+// Copyright 2023 the cncf-fuzzing authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package utils
+
+import (
+	"testing"
+)
+
+func FuzzParsePEMPrivateKey(f *testing.F) {
+	f.Fuzz(func(t *testing.T, pemBytes []byte, passphrase string) {
+		_, _ = ParsePEMPrivateKey(pemBytes, passphrase)
+	})
+}


### PR DESCRIPTION
Adds a fuzzer for `ParsePEMPrivateKey`.

Signed-off-by: AdamKorcz <adam@adalogics.com>