### PR TITLE
Revert "crossplane: fix broken fuzzer"

### DIFF
--- a/projects/crossplane/composition_fuzzer.go
+++ b/projects/crossplane/composition_fuzzer.go
@@ -28,7 +28,11 @@ func FuzzNewCompositionRevision(data []byte) int {
 	if err != nil {
 		return 0
 	}
+	compSpecHash, err := f.GetString()
+	if err != nil {
+		return 0
+	}
 
-	_ = NewCompositionRevision(c, int64(revision))
+	_ = NewCompositionRevision(c, int64(revision), compSpecHash)
 	return 1
 }


### PR DESCRIPTION
Reverts cncf/cncf-fuzzing#307

The API still takes 3 parameters, although this run said otherwise: https://github.com/crossplane/crossplane/actions/runs/4019056529/jobs/6905434736. Reverting to not break the continuous build.

Signed-off-by: AdamKorcz <adam@adalogics.com>