### PR TITLE
distribution: fix spurious fuzz failures

### DIFF
--- a/projects/distribution/reference_fuzzer2.go
+++ b/projects/distribution/reference_fuzzer2.go
@@ -42,6 +42,9 @@ func FuzzAllNormalizeApis(data []byte) int {
 		return 0
 	}
 	n, err := ParseDockerRef(ref)
+	if err != nil {
+		return 0
+	}
 	_ = TagNameOnly(n)
 	ref, err = f.GetString()
 	if err != nil {


### PR DESCRIPTION
Check the error-return value of reference.ParseDockerRef so the fuzz test stops blindly calling reference.TagNameOnly with a nil argument.