### PR TITLE
Keycloak: Add mock web server service and relative dependencies

### DIFF
--- a/projects/keycloak/AuthzClientFuzzer.java
+++ b/projects/keycloak/AuthzClientFuzzer.java
@@ -13,10 +13,14 @@
 // limitations under the License.
 //
 ///////////////////////////////////////////////////////////////////////////
+import com.code_intelligence.jazzer.api.BugDetectors;
 import com.code_intelligence.jazzer.api.FuzzedDataProvider;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.function.BiPredicate;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
 import org.keycloak.authorization.client.AuthzClient;
 
 /**
@@ -29,13 +33,62 @@ public class AuthzClientFuzzer {
   // Temporary set to empty url, will point
   // to a mock server when it is implemented
   private static final String keycloakJson =
-      "{\"realm\":\"oss-fuzz\",\"realm-public-key\":\"TESTING_KEY\",\"auth-server-url\":\"\",\"ssl-required\":\"internal\",\"resource\":\"connect\",\"public-client\":false}";
+      "{\"realm\":\"oss-fuzz\",\"realm-public-key\":\"TESTING_KEY\",\"auth-server-url\":\"SERVER_URL\",\"ssl-required\":\"internal\",\"resource\":\"connect\",\"public-client\":false}";
+  private static MockWebServer server;
+  private static String serverUrl;
+
+  public static void fuzzerInitialize() {
+    // Prepare MockWebServer
+    try {
+      // Start the mock web server
+      server = new MockWebServer();
+      server.start();
+
+      // Retrieve host name and port of the mock web server
+      String serverHost = server.getHostName();
+      Integer serverPort = server.getPort();
+
+      // Mock web server url
+      serverUrl = "http://" + serverHost + ":" + serverPort;
+
+      // Create BiPredicate to allow connection to the mock server
+      BiPredicate<String, Integer> urlFilter = (host, port) -> {
+        return host.equals(serverHost) && port.equals(serverPort);
+      };
+
+      // Enable the fuzzer to connect only to the mock web server, deny any other connections
+      BugDetectors.allowNetworkConnections(urlFilter);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  public static void fuzzerTearDown() {
+    // Shutdown the mock web server
+    try {
+      if (server != null) {
+        server.shutdown();
+      }
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
 
   public static void fuzzerTestOneInput(FuzzedDataProvider data) {
     try {
+      // Create a random mock response for the mock web server
+      // Then enqueue to the server to serve possible request
+      MockResponse mockResponse = new MockResponse();
+      mockResponse.setBody(data.consumeString(data.remainingBytes() / 2));
+      mockResponse.addHeader("Content-Type", "application/json");
+      server.enqueue(mockResponse);
+
+      // Set the auth-url to the mock web server
+      String jsonString = keycloakJson.replace("SERVER_URL", serverUrl);
+
       // Create the authz client object for fuzzing
-      AuthzClient client = AuthzClient.create(
-          new ByteArrayInputStream(keycloakJson.getBytes(StandardCharsets.UTF_8)));
+      AuthzClient client =
+          AuthzClient.create(new ByteArrayInputStream(jsonString.getBytes(StandardCharsets.UTF_8)));
 
       // Randomly fuzz different version of the protection and authorization methods
       // with different parameter combinations

--- a/projects/keycloak/AuthzClientFuzzer.java
+++ b/projects/keycloak/AuthzClientFuzzer.java
@@ -51,13 +51,9 @@ public class AuthzClientFuzzer {
       // Mock web server url
       serverUrl = "http://" + serverHost + ":" + serverPort;
 
-      // Create BiPredicate to allow connection to the mock server
-      BiPredicate<String, Integer> urlFilter = (host, port) -> {
-        return host.equals(serverHost) && port.equals(serverPort);
-      };
-
       // Enable the fuzzer to connect only to the mock web server, deny any other connections
-      BugDetectors.allowNetworkConnections(urlFilter);
+      BugDetectors.allowNetworkConnections(
+          (host, port) -> host.equals(serverHost) && port.equals(serverPort));
     } catch (IOException e) {
       throw new RuntimeException(e);
     }

--- a/projects/keycloak/PolicyEnforcerFuzzer.java
+++ b/projects/keycloak/PolicyEnforcerFuzzer.java
@@ -47,7 +47,6 @@ public class PolicyEnforcerFuzzer {
   private static String serverUrl;
 
   public static void fuzzerInitialize() {
-    // Prepare MockWebServer
     try {
       // Start the mock web server
       server = new MockWebServer();
@@ -60,13 +59,9 @@ public class PolicyEnforcerFuzzer {
       // Mock web server url
       serverUrl = "http://" + serverHost + ":" + serverPort;
 
-      // Create BiPredicate to allow connection to the mock server
-      BiPredicate<String, Integer> urlFilter = (host, port) -> {
-        return host.equals(serverHost) && port.equals(serverPort);
-      };
-
       // Enable the fuzzer to connect only to the mock web server, deny any other connections
-      BugDetectors.allowNetworkConnections(urlFilter);
+      BugDetectors.allowNetworkConnections(
+          (host, port) -> host.equals(serverHost) && port.equals(serverPort));
     } catch (IOException e) {
       throw new RuntimeException(e);
     }

--- a/projects/keycloak/build.sh
+++ b/projects/keycloak/build.sh
@@ -76,8 +76,16 @@ sed -i "s#<pluginManagement>#$PLUGIN#g" ./pom.xml
 ## Execute maven build
 $MVN clean package -pl "$EXCLUDE_MODULE" $MAVEN_ARGS
 
-# Dependency for PolicyEnforcerFuzzer
+# Dependency for Mockito and MockWebService functionality
+# Used by PolicyEnforcerFuzzer and AuthzClientFuzzer
 wget https://repo1.maven.org/maven2/org/mockito/mockito-core/5.4.0/mockito-core-5.4.0.jar
+wget https://repo1.maven.org/maven2/com/squareup/okhttp3/mockwebserver/4.11.0/mockwebserver-4.11.0.jar
+wget https://repo1.maven.org/maven2/com/squareup/okhttp3/okhttp/4.11.0/okhttp-4.11.0.jar
+wget https://repo1.maven.org/maven2/junit/junit/4.13/junit-4.13.jar
+wget https://repo1.maven.org/maven2/org/jetbrains/kotlin/kotlin-stdlib-common/1.6.10/kotlin-stdlib-common-1.6.10.jar
+wget https://repo1.maven.org/maven2/org/jetbrains/kotlin/kotlin-stdlib/1.6.10/kotlin-stdlib-1.6.10.jar
+wget https://repo1.maven.org/maven2/com/squareup/okio/okio/3.2.0/okio-3.2.0.jar
+wget https://repo1.maven.org/maven2/com/squareup/okio/okio-jvm/3.2.0/okio-jvm-3.2.0.jar
 
 RUNTIME_CLASSPATH=
 
@@ -85,7 +93,10 @@ for JARFILE in $(find ./ -name "*.jar")
 do
   if [[ "$JARFILE" == *"core/"* ]] || [[ "$JARFILE" == *"saml-core/"* ]] || \
   [[ "$JARFILE" == *"saml-core-api/"* ]] || [[ "$JARFILE" == *"common/"* ]] || \
-  [[ "$JARFILE" == *"crypto/"* ]] || [[ "$JARFILE" == *"mockito"* ]]
+  [[ "$JARFILE" == *"crypto/"* ]] || [[ "$JARFILE" == *"mockito"* ]] || \
+  [[ "$JARFILE" == *"mockwebserver"* ]] || [[ "$JARFILE" == *"okhttp"* ]] || \
+  [[ "$JARFILE" == *"junit"* ]] || [[ "$JARFILE" == *"kotlin"* ]] || \
+  [[ "$JARFILE" == *"okio"* ]]
   then
     # Exclude original jar as all build jars and dependency jars are shaded into a single jar
     if [[ "$JARFILE" != *"original"* ]]


### PR DESCRIPTION
Some fuzzer class requires HTTP connection to get response and further process on those response. For example the fuzzers in #423 and #425. In order to accommodate this setting, this PR add the okhttp3.MockWebServer service and related dependencies to allow these fuzzers to create a MockWebServer for random response. The fuzzer points the http auth url to the MockWebServer initialise during fuzzer initialisation process and generate random mock response to trigger those response processing logic for fuzzing. By default, HTTP connection are banned by Jazzer BugDetectors. Specific exclusion predicate can be set to allow HTTP connection to specific hostname and port. This is done in the fuzzerInitialize of the fuzzers to ensure only connection to the localhost mock web server is allowed.