### PR TITLE
keycloak: Move JDK 17 installation to Dockerfile

### DIFF
--- a/projects/keycloak/build.sh
+++ b/projects/keycloak/build.sh
@@ -15,14 +15,6 @@
 #
 ################################################################################
 
-# Retrieve JDK-17
-wget https://download.java.net/openjdk/jdk17/ri/openjdk-17+35_linux-x64_bin.tar.gz -O openjdk-17.tar.gz
-tar -zxf openjdk-17.tar.gz
-rm -f openjdk-17.tar.gz
-cp -r jdk-17 $OUT/
-JAVA_HOME=$OUT/jdk-17
-PATH=$JAVA_HOME/bin:$PATH
-
 # Build Keycloak
 
 ## Maven build arguments


### PR DESCRIPTION
Move the JDK installation logic to oss-fuzz Dockerfile in https://github.com/google/oss-fuzz/pull/10809 to avoid missing native binary from headless version.