### PR TITLE
keycloak: Fix java home

### DIFF
--- a/projects/keycloak/build.sh
+++ b/projects/keycloak/build.sh
@@ -118,9 +118,7 @@ else
   mem_settings='-Xmx2048m:-Xss1024k'
 fi
 
-export JAVA_HOME=\$this_dir/jdk-17
 export LD_LIBRARY_PATH=\"\$JAVA_HOME/lib/server\":\$this_dir
-export PATH=\$JAVA_HOME/bin:\$PATH
 
 CURRENT_JAVA_VERSION=\$(java --version | head -n1)
 


### PR DESCRIPTION
After the changes in #440. The JDK-17 is now installed by apt command in the Dockerfile. The JAVA_HOME and PATH will automatically set by the apt command and thus the manual config of this two environment variable is not needed anymore.