### PR TITLE
keycloak: Move object mocking location

### DIFF
--- a/projects/keycloak/AuthorizationTokenServiceFuzzer.java
+++ b/projects/keycloak/AuthorizationTokenServiceFuzzer.java
@@ -52,143 +52,79 @@ import org.mockito.Mockito;
  * class in the services authorization package.
  */
 public class AuthorizationTokenServiceFuzzer {
+  private static RealmModel realmModel;
+  private static ClientModel clientModel;
+  private static HttpHeaders headers;
+  private static ClientConnection clientConnection;
+  private static KeycloakSession session;
+
+  public static void fuzzerInitialize() {
+    mockInstance();
+  }
+
   public static void fuzzerTestOneInput(FuzzedDataProvider data) {
     try {
-      // Retrieve mock realm model instance
-      RealmModel realmModel = mockRealmModel(data);
+      // Randomize mock fields of mocked object instance
+      randomizeMockData(data);
 
-      // Retrieve mock client model instance
-      ClientModel clientModel = mockClientModel(data, realmModel);
-
-      // Retrieve mock keycloak session instance
-      KeycloakSession session = mockKeycloakSession(data, clientModel, realmModel);
-
-      // Retrieve a mocked KeycloakAuthorizationRequest instance
-      AuthorizationTokenService.KeycloakAuthorizationRequest request =
-          mockKeycloakAuthorizationRequest(data, session, realmModel);
+      // Create KeycloakAuthorizationRequest instance
+      AuthorizationTokenService.KeycloakAuthorizationRequest request = createKeycloakAuthorizationRequest(data);
 
       // Invoke the authorize method
       AuthorizationTokenService.instance().authorize(request);
     } catch (CorsErrorResponseException e) {
       // Known exception
+    } finally {
+      // Suggest the java garbage collector to clean up unused memory
+      System.gc();
     }
   }
 
-  private static RealmModel mockRealmModel(FuzzedDataProvider data) {
-    // Create and mock RealmModel
-    RealmModel realmModel = Mockito.mock(RealmModel.class);
-    Mockito.when(realmModel.getId()).thenReturn(data.consumeString(data.remainingBytes() / 2));
-    Mockito.when(realmModel.isEventsEnabled()).thenReturn(data.consumeBoolean());
+  private static void mockInstance() {
+    mockRealmModel();
+    mockClientModel();
+    mockHttpHeaders();
+    mockClientConnection();
+    mockKeycloakSession();
+  }
+
+  private static void randomizeMockData(FuzzedDataProvider data) {
+    randomizeRealmModel(data);
+    randomizeClientModel(data);
+    randomizeHttpHeaders(data);
+    randomizeClientConnection(data);
+    randomizeKeycloakSession(data);
+  }
+
+  private static void mockRealmModel() {
+    // Create and mock RealmModel with static data
+    realmModel = Mockito.mock(RealmModel.class);
     Mockito.when(realmModel.getName()).thenReturn("realm");
-    Mockito.when(realmModel.getDefaultSignatureAlgorithm())
-        .thenReturn(data.consumeString(data.remainingBytes() / 2));
-
-    return realmModel;
   }
 
-  private static ClientModel mockClientModel(FuzzedDataProvider data, RealmModel realmModel) {
-    // Create and mock ClientModel instance with random data
-    ClientModel model = Mockito.mock(ClientModel.class);
-    Mockito.when(model.getId()).thenReturn(data.consumeString(data.remainingBytes() / 2));
-    Mockito.when(model.getClientId()).thenReturn(data.consumeString(data.remainingBytes() / 2));
-    Mockito.when(model.getName()).thenReturn(data.consumeString(data.remainingBytes() / 2));
-    Mockito.when(model.getDescription()).thenReturn(data.consumeString(data.remainingBytes() / 2));
-    Mockito.when(model.isEnabled()).thenReturn(data.consumeBoolean());
-    Mockito.when(model.isAlwaysDisplayInConsole()).thenReturn(data.consumeBoolean());
-    Mockito.when(model.isSurrogateAuthRequired()).thenReturn(data.consumeBoolean());
-    Mockito.when(model.getWebOrigins())
-        .thenReturn(Set.of(data.consumeString(data.remainingBytes() / 2)));
-    Mockito.when(model.getRedirectUris())
-        .thenReturn(Set.of(data.consumeString(data.remainingBytes() / 2)));
-    Mockito.when(model.getManagementUrl())
-        .thenReturn(data.consumeString(data.remainingBytes() / 2));
-    Mockito.when(model.getRootUrl()).thenReturn(data.consumeString(data.remainingBytes() / 2));
-    Mockito.when(model.getBaseUrl()).thenReturn(data.consumeString(data.remainingBytes() / 2));
-    Mockito.when(model.getNodeReRegistrationTimeout()).thenReturn(data.consumeInt());
-    Mockito.when(model.getClientAuthenticatorType())
-        .thenReturn(data.consumeString(data.remainingBytes() / 2));
-    Mockito.when(model.validateSecret(Mockito.any(String.class))).thenReturn(data.consumeBoolean());
-    Mockito.when(model.getSecret()).thenReturn(data.consumeString(data.remainingBytes() / 2));
-    Mockito.when(model.getRegistrationToken())
-        .thenReturn(data.consumeString(data.remainingBytes() / 2));
-    Mockito.when(model.getProtocol()).thenReturn(data.consumeString(data.remainingBytes() / 2));
-    Mockito.when(model.getAttribute(Mockito.any(String.class)))
-        .thenReturn(data.consumeString(data.remainingBytes() / 2));
-    Mockito.when(model.getAuthenticationFlowBindingOverride(Mockito.any(String.class)))
-        .thenReturn(data.consumeString(data.remainingBytes() / 2));
-    Mockito.when(model.isFrontchannelLogout()).thenReturn(data.consumeBoolean());
-    Mockito.when(model.isFullScopeAllowed()).thenReturn(data.consumeBoolean());
-
-    Map<String, String> map = new HashMap<String, String>();
-    map.put(data.consumeString(data.remainingBytes() / 2),
-        data.consumeString(data.remainingBytes() / 2));
-    Mockito.when(model.getAttributes()).thenReturn(map);
-    Mockito.when(model.getAuthenticationFlowBindingOverrides()).thenReturn(map);
-    Mockito.when(model.getRealm()).thenReturn(realmModel);
-
-    return model;
+  private static void mockClientModel() {
+    // Create and mock ClientModel with static data
+    clientModel = Mockito.mock(ClientModel.class);
+    Mockito.when(clientModel.getRealm()).thenReturn(realmModel);
   }
 
-  private static HttpHeaders mockHttpHeaders(FuzzedDataProvider data) {
-    // Create and mock HttpHeaders
-    HttpHeaders headers = Mockito.mock(HttpHeaders.class);
-    MultivaluedMap<String, String> map = new MultivaluedHashMap<String, String>();
-    map.add("Origin", "Origin" + data.consumeString(data.remainingBytes() / 2));
-    Mockito.when(headers.getRequestHeaders()).thenReturn(map);
-
-    return headers;
+  private static void mockHttpHeaders() {
+    // Create and mock HttpHeaders with static data
+    headers = Mockito.mock(HttpHeaders.class);
   }
 
-  private static ClientConnection mockClientConnection(FuzzedDataProvider data) {
-    // Mock ClientConnection instance
-    ClientConnection clientConnection = Mockito.mock(ClientConnection.class);
-    Mockito.when(clientConnection.getRemoteAddr())
-        .thenReturn(data.consumeString(data.remainingBytes() / 2));
-    Mockito.when(clientConnection.getRemoteHost())
-        .thenReturn(data.consumeString(data.remainingBytes() / 2));
-    Mockito.when(clientConnection.getLocalAddr())
-        .thenReturn(data.consumeString(data.remainingBytes() / 2));
-    Mockito.when(clientConnection.getRemotePort()).thenReturn(data.consumeInt(1, 65536));
-    Mockito.when(clientConnection.getLocalPort()).thenReturn(data.consumeInt(1, 65536));
-
-    return clientConnection;
+  private static void mockClientConnection() {
+    // Create and mock ClientConnection with static data
+    clientConnection = Mockito.mock(ClientConnection.class);
   }
 
-  private static KeycloakSession mockKeycloakSession(
-      FuzzedDataProvider data, ClientModel clientModel, RealmModel realmModel) {
-    // Create and mock KeycloakSession
-    KeycloakSession session = Mockito.mock(KeycloakSession.class);
+  private static void mockKeycloakSession() {
+    // Create and mock KeycloakSession with static data
+    session = Mockito.mock(KeycloakSession.class);
 
     // Create and mock KeycloakSessionFactory object
     KeycloakSessionFactory keycloakSessionFactory = Mockito.mock(KeycloakSessionFactory.class);
     Mockito.doReturn(session).when(keycloakSessionFactory).create();
-
-    // Retrieve mock HttpHeaders instance
-    HttpHeaders headers = mockHttpHeaders(data);
-
-    // Retrieve mock ClientConnection instance
-    ClientConnection connection = mockClientConnection(data);
-
-    MultivaluedMap<String, String> map = new MultivaluedHashMap<String, String>();
-    map.add(data.consumeString(data.remainingBytes() / 2),
-        data.consumeString(data.remainingBytes() / 2));
-
-    // Create and mock UriInfo instance
-    KeycloakUriInfo uriInfo = Mockito.mock(KeycloakUriInfo.class);
-    try {
-      Mockito.when(uriInfo.getBaseUri()).thenReturn(new URI("http://localhost"));
-    } catch (URISyntaxException e) {
-      // Known exception
-    }
-    Mockito.when(uriInfo.getQueryParameters()).thenReturn(map);
-
-    // Create and mock KeycloakContext
-    KeycloakContext keycloakContext = Mockito.mock(KeycloakContext.class);
-    Mockito.when(keycloakContext.getClient()).thenReturn(clientModel);
-    Mockito.when(keycloakContext.getRealm()).thenReturn(realmModel);
-    Mockito.when(keycloakContext.getRequestHeaders()).thenReturn(headers);
-    Mockito.when(keycloakContext.getConnection()).thenReturn(connection);
-    Mockito.when(keycloakContext.getUri()).thenReturn(uriInfo);
 
     // Create and mock RealmProvider
     RealmProvider realmProvider = Mockito.mock(RealmProvider.class);
@@ -202,30 +138,116 @@ public class AuthorizationTokenServiceFuzzer {
     Mockito.when(clientProvider.getClientByClientId(Mockito.any(), Mockito.any()))
         .thenReturn(clientModel);
 
+    // Create mock return for KeycloakSessionObject
+    Mockito.when(session.getKeycloakSessionFactory()).thenReturn(keycloakSessionFactory);
+    Mockito.doReturn(realmProvider).when(session).realms();
+    Mockito.doReturn(clientProvider).when(session).clients();
+  }
+
+  private static void randomizeRealmModel(FuzzedDataProvider data) {
+    // Randomize mock fields of Realm Model instance
+    Mockito.when(realmModel.getId()).thenReturn(data.consumeString(data.remainingBytes() / 2));
+    Mockito.when(realmModel.isEventsEnabled()).thenReturn(data.consumeBoolean());
+    Mockito.when(realmModel.getDefaultSignatureAlgorithm())
+        .thenReturn(data.consumeString(data.remainingBytes() / 2));
+  }
+
+  private static void randomizeClientModel(FuzzedDataProvider data) {
+    // Randomize mock fields of Client Model instance
+    Mockito.when(clientModel.getId()).thenReturn(data.consumeString(data.remainingBytes() / 2));
+    Mockito.when(clientModel.getClientId()).thenReturn(data.consumeString(data.remainingBytes() / 2));
+    Mockito.when(clientModel.getName()).thenReturn(data.consumeString(data.remainingBytes() / 2));
+    Mockito.when(clientModel.getDescription()).thenReturn(data.consumeString(data.remainingBytes() / 2));
+    Mockito.when(clientModel.isEnabled()).thenReturn(data.consumeBoolean());
+    Mockito.when(clientModel.isAlwaysDisplayInConsole()).thenReturn(data.consumeBoolean());
+    Mockito.when(clientModel.getWebOrigins())
+        .thenReturn(Set.of(data.consumeString(data.remainingBytes() / 2)));
+    Mockito.when(clientModel.getRedirectUris())
+        .thenReturn(Set.of(data.consumeString(data.remainingBytes() / 2)));
+    Mockito.when(clientModel.getManagementUrl())
+        .thenReturn(data.consumeString(data.remainingBytes() / 2));
+    Mockito.when(clientModel.getRootUrl()).thenReturn(data.consumeString(data.remainingBytes() / 2));
+    Mockito.when(clientModel.getBaseUrl()).thenReturn(data.consumeString(data.remainingBytes() / 2));
+    Mockito.when(clientModel.getNodeReRegistrationTimeout()).thenReturn(data.consumeInt());
+    Mockito.when(clientModel.getClientAuthenticatorType())
+        .thenReturn(data.consumeString(data.remainingBytes() / 2));
+    Mockito.when(clientModel.validateSecret(Mockito.any(String.class))).thenReturn(data.consumeBoolean());
+    Mockito.when(clientModel.getSecret()).thenReturn(data.consumeString(data.remainingBytes() / 2));
+    Mockito.when(clientModel.getRegistrationToken())
+        .thenReturn(data.consumeString(data.remainingBytes() / 2));
+    Mockito.when(clientModel.getProtocol()).thenReturn(data.consumeString(data.remainingBytes() / 2));
+    Mockito.when(clientModel.getAttribute(Mockito.any(String.class)))
+        .thenReturn(data.consumeString(data.remainingBytes() / 2));
+    Mockito.when(clientModel.getAuthenticationFlowBindingOverride(Mockito.any(String.class)))
+        .thenReturn(data.consumeString(data.remainingBytes() / 2));
+    Mockito.when(clientModel.isFrontchannelLogout()).thenReturn(data.consumeBoolean());
+    Mockito.when(clientModel.isFullScopeAllowed()).thenReturn(data.consumeBoolean());
+
+    Map<String, String> map = new HashMap<String, String>();
+    map.put(data.consumeString(data.remainingBytes() / 2),
+        data.consumeString(data.remainingBytes() / 2));
+    Mockito.when(clientModel.getAttributes()).thenReturn(map);
+    Mockito.when(clientModel.getAuthenticationFlowBindingOverrides()).thenReturn(map);
+  }
+
+  private static void randomizeHttpHeaders(FuzzedDataProvider data) {
+    // Randomize mock fields of Http Headers instance
+    MultivaluedMap<String, String> map = new MultivaluedHashMap<String, String>();
+    map.add("Origin", "Origin" + data.consumeString(data.remainingBytes() / 2));
+
+    Mockito.when(headers.getRequestHeaders()).thenReturn(map);
+  }
+
+  private static void randomizeClientConnection(FuzzedDataProvider data) {
+    // Randomize mock fields of Client Connection instance
+    Mockito.when(clientConnection.getRemoteAddr())
+        .thenReturn(data.consumeString(data.remainingBytes() / 2));
+    Mockito.when(clientConnection.getRemoteHost())
+        .thenReturn(data.consumeString(data.remainingBytes() / 2));
+    Mockito.when(clientConnection.getLocalAddr())
+        .thenReturn(data.consumeString(data.remainingBytes() / 2));
+    Mockito.when(clientConnection.getRemotePort()).thenReturn(data.consumeInt(1, 65536));
+    Mockito.when(clientConnection.getLocalPort()).thenReturn(data.consumeInt(1, 65536));
+  }
+
+  private static void randomizeKeycloakSession(FuzzedDataProvider data) {
+    // Randomize mock fields of Keycloak Session instance
+
+    // Create and mock UriInfo instance
+    MultivaluedMap<String, String> map = new MultivaluedHashMap<String, String>();
+    map.add(data.consumeString(data.remainingBytes() / 2),
+        data.consumeString(data.remainingBytes() / 2));
+    KeycloakUriInfo uriInfo = Mockito.mock(KeycloakUriInfo.class);
+    try {
+      Mockito.when(uriInfo.getBaseUri()).thenReturn(new URI("http://localhost"));
+    } catch (URISyntaxException e) {
+      // Known exception
+    }
+    Mockito.when(uriInfo.getQueryParameters()).thenReturn(map);
+
+    // Create and mock KeycloakContext
+    KeycloakContext keycloakContext = Mockito.mock(KeycloakContext.class);
+    Mockito.when(keycloakContext.getClient()).thenReturn(clientModel);
+    Mockito.when(keycloakContext.getRealm()).thenReturn(realmModel);
+    Mockito.when(keycloakContext.getRequestHeaders()).thenReturn(headers);
+    Mockito.when(keycloakContext.getConnection()).thenReturn(clientConnection);
+    Mockito.when(keycloakContext.getUri()).thenReturn(uriInfo);
+
     // Create and mock TransactionManager
     KeycloakTransactionManager transactionManager = Mockito.mock(KeycloakTransactionManager.class);
     Mockito.when(transactionManager.getJTAPolicy())
         .thenReturn(data.pickValue(EnumSet.allOf(KeycloakTransactionManager.JTAPolicy.class)));
 
-    // Create mock return for KeycloakSessionObject
+    // Create mock return for KeycloakSession instance
     Mockito.when(session.getContext()).thenReturn(keycloakContext);
-    Mockito.when(session.getKeycloakSessionFactory()).thenReturn(keycloakSessionFactory);
     Mockito.when(session.getTransactionManager()).thenReturn(transactionManager);
-    Mockito.doReturn(realmProvider).when(session).realms();
-    Mockito.doReturn(clientProvider).when(session).clients();
-
-    return session;
   }
 
   private static AuthorizationTokenService.KeycloakAuthorizationRequest
-  mockKeycloakAuthorizationRequest(
-      FuzzedDataProvider data, KeycloakSession session, RealmModel realmModel) {
+  createKeycloakAuthorizationRequest(FuzzedDataProvider data) {
     // Create AuthorizationProvider instance
     AuthorizationProvider authorizationProvider =
         new DefaultAuthorizationProviderFactory().create(session);
-
-    // Retrieve mock ClientConnection instance
-    ClientConnection clientConnection = session.getContext().getConnection();
 
     // Create EventBuilder instance
     EventBuilder eventBuilder = new EventBuilder(realmModel, session, clientConnection);
@@ -233,7 +255,7 @@ public class AuthorizationTokenServiceFuzzer {
 
     // Prepare HttpRequest instance with the mocked object
     HttpRequest httpRequest = Mockito.mock(HttpRequest.class);
-    Mockito.doReturn(session.getContext().getRequestHeaders()).when(httpRequest).getHttpHeaders();
+    Mockito.doReturn(headers).when(httpRequest).getHttpHeaders();
 
     // Create Cors instance
     Cors cors = new Cors(httpRequest);

--- a/projects/keycloak/JsonSerializerDeserializationFuzzer.java
+++ b/projects/keycloak/JsonSerializerDeserializationFuzzer.java
@@ -20,7 +20,6 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;


### PR DESCRIPTION
It is discovered that some fuzzer runs into OutOfMemoryError because of GC overhead limit exceeded. JDK garbage collection (GC) will try to free up memory when some unused object is found. If there is too much repeating instance creation and dropped, the GC will take up high working load. When the working load is higher than the preset overhead of the JVM (normally set to 98%), an OutOfMemoryError is thrown. Some of the fuzzers of keycloak create a new set of mock object in every iteration. It means that it will build up a high amount of "garbage" for the GC to work with. This eventually reach the GC overhead limit. This PR fixes one of the fuzzer to try moving the mock object creation in the fuzzerInitialize method (which only execute once when the fuzzer start and will not execute per iteration) and only randomize the mock return of these object in each iteration to decrease the GC work overhead. 