### PR TITLE
keycloak:  Fix internal exception

### DIFF
--- a/projects/keycloak/ServicesUtilsFuzzer.java
+++ b/projects/keycloak/ServicesUtilsFuzzer.java
@@ -170,6 +170,11 @@ public class ServicesUtilsFuzzer {
       }
     } catch (GeneralSecurityException | PatternSyntaxException e) {
       // Known exception
+    } catch (RuntimeException e) {
+      if (!e.getMessage().contains("com.google.zxing.WriterException")) {
+        // Unknown internal exception
+        throw e;
+      }
     }
   }
 }


### PR DESCRIPTION
Totputils method capture the underlying exceptions and throw a Runtime Exception. This PR fixes the exception handling to capture the thrown Runtime Exception and check if it is an expected cause, otherwise, the original RuntimeException are thrown out. This could solve some of the problem by handled and expected exceptions.