### PR TITLE
keycloak: Fix build script

### DIFF
--- a/projects/keycloak/build.sh
+++ b/projects/keycloak/build.sh
@@ -120,7 +120,9 @@ fi
 
 apt install openjdk-17-jdk -y
 
+export JAVA_HOME=\"/usr/lib/jvm/java-17-openjdk-amd64\"
 export LD_LIBRARY_PATH=\"\$JAVA_HOME/lib/server\":\$this_dir
+export PATH=\$JAVA_HOME/bin:\$PATH
 
 CURRENT_JAVA_VERSION=\$(java --version | head -n1)
 

--- a/projects/keycloak/build.sh
+++ b/projects/keycloak/build.sh
@@ -118,6 +118,8 @@ else
   mem_settings='-Xmx2048m:-Xss1024k'
 fi
 
+apt install openjdk-17-jdk -y
+
 export LD_LIBRARY_PATH=\"\$JAVA_HOME/lib/server\":\$this_dir
 
 CURRENT_JAVA_VERSION=\$(java --version | head -n1)


### PR DESCRIPTION
Add jdk 17 installation to run script and fix wrong removal of JAVA_HOME and PATH in #441.