### PR TITLE
Fix missing runc-dmz failure for runc

### DIFF
--- a/projects/runc/build.sh
+++ b/projects/runc/build.sh
@@ -43,4 +43,5 @@ compile_go_fuzzer $RUNC_PATH/libcontainer/intelrdt FuzzParseMonFeatures parse_mo
 mv $RUNC_FUZZERS/libcontainer_fuzzer.go $SRC/runc/libcontainer/
 mv $SRC/runc/libcontainer/container_linux_test.go \
    $SRC/runc/libcontainer/container_linux_test_fuzz.go
+CFLAGS=-O1 make -B runc-dmz || echo -n >runc-dmz
 compile_go_fuzzer $RUNC_PATH/libcontainer FuzzStateApi state_api_fuzzer


### PR DESCRIPTION
The following error would occur when building fuzz driver `FuzzStateApi` for runc after migrating go version to 1.21.0, which would lead to building failure.
```bash
Running go-fuzz -tags gofuzz -func FuzzStateApi -o state_api_fuzzer.a github.com/opencontainers/runc/libcontainer
libcontainer/dmz/dmz_linux.go:21:12: pattern runc-dmz: no matching files found
failed to build packages:exit status 1
ERROR:__main__:Building fuzzers failed.
```
AFAIU, the reason is runc requires `runc-dmz` binary available for building in [libcontainer/dmz/dmz_linux.go](https://github.com/opencontainers/runc/blob/c494c475bdf7d2fd3b44c79c9c1df7b234ed69dc/libcontainer/dmz/dmz_linux.go#L20C1-L21C20), while go build process would ignore `go:generate` when the target file is not directly used.

Although it would not be the best approach to fix the error, the error is fixed by manually running the compiling for `runc-dmz` before building the fuzz driver.

PS. Compile with default ossfuzz CFLAGS would trigger ASAN and DWARF errors, leading to compile failure.