### PR TITLE
Bump go version in distribution project.

### DIFF
--- a/projects/distribution/build.sh
+++ b/projects/distribution/build.sh
@@ -6,11 +6,11 @@ set -x
 
 apt-get update && apt-get install -y wget
 cd $SRC
-wget https://go.dev/dl/go1.20.11.linux-amd64.tar.gz
+wget https://go.dev/dl/go1.21.9.linux-amd64.tar.gz
 
 mkdir temp-go
 rm -rf /root/.go/*
-tar -C temp-go/ -xzf go1.20.11.linux-amd64.tar.gz
+tar -C temp-go/ -xzf go1.21.9.linux-amd64.tar.gz
 mv temp-go/go/* /root/.go/
 cd $SRC/distribution
 


### PR DESCRIPTION
[distribution/distribution](https://github.com/distribution/distribution) project no longer supports Go versions < 1.20. 

Deprecating support for the old version of Go runtimes started causing the following fuzzing failures:

```
"go: go.mod file indicates go 1.21, but maximum version supported by tidy is 1.20"
```

This PR bumps the Go version to the oldest supported version by the distribution project.