### PR TITLE
keycloak: Refactor fuzzers

### DIFF
--- a/projects/keycloak/AuthenticatorFuzzer.java
+++ b/projects/keycloak/AuthenticatorFuzzer.java
@@ -27,32 +27,25 @@ public class AuthenticatorFuzzer {
   public static void fuzzerTestOneInput(FuzzedDataProvider data) {
     try {
       Authenticator authenticator = null;
-      AuthenticatorFactory factory = null;
       AuthenticationFlowContext context = BaseHelper.createAuthenticationFlowContext(data);
 
       switch (data.consumeInt(1, 4)) {
         case 1:
           authenticator = AttemptedAuthenticator.SINGLETON;
-          break;
         case 2:
           authenticator = new AllowAccessAuthenticatorFactory().create(context.getSession());
-          break;
         case 3:
           authenticator = new DenyAccessAuthenticatorFactory().create(context.getSession());
-          break;
         case 4:
-          factory = new UserSessionLimitsAuthenticatorFactory();
+          AuthenticatorFactory factory = new UserSessionLimitsAuthenticatorFactory();
           context =
               BaseHelper.randomizeContext(
                   context, factory.getConfigProperties(), factory.getRequirementChoices());
           authenticator = factory.create(context.getSession());
-          break;
       }
 
       // Fuzz the authenticate method
-      if (authenticator != null) {
-        authenticator.authenticate(context);
-      }
+      authenticator.authenticate(context);  
     } catch (RuntimeException e) {
       // Known exception
     }

--- a/projects/keycloak/BrokerAuthenticatorFuzzer.java
+++ b/projects/keycloak/BrokerAuthenticatorFuzzer.java
@@ -59,13 +59,10 @@ public class BrokerAuthenticatorFuzzer {
           break;
       }
 
-      // Fuzz the authenticate method
-      if (factory != null) {
-        Authenticator authenticator = factory.create(null);
-        AuthenticationFlowContext context = BaseHelper.createAuthenticationFlowContext(data);
-        BaseHelper.randomizeContext(context, null, factory.getRequirementChoices());
-        authenticator.authenticate(context);
-      }
+      Authenticator authenticator = factory.create(null);
+      AuthenticationFlowContext context = BaseHelper.createAuthenticationFlowContext(data);
+      BaseHelper.randomizeContext(context, null, factory.getRequirementChoices());
+      authenticator.authenticate(context);
     } catch (RuntimeException e) {
       // Known exception
     }

--- a/projects/keycloak/CertificateUtilsProviderFuzzer.java
+++ b/projects/keycloak/CertificateUtilsProviderFuzzer.java
@@ -61,13 +61,10 @@ public class CertificateUtilsProviderFuzzer {
       switch (data.consumeInt(1, 3)) {
         case 1:
           provider = new BCCertificateUtilsProvider();
-          break;
         case 2:
           provider = new ElytronCertificateUtilsProvider();
-          break;
         case 3:
           provider = new BCFIPSCertificateUtilsProvider();
-          break;
       }
 
       // Randomly choose which method to invoke
@@ -77,37 +74,32 @@ public class CertificateUtilsProviderFuzzer {
           cert =
               (X509Certificate)
                   cf.generateCertificate(
-                      new ByteArrayInputStream(data.consumeBytes(data.remainingBytes() / 2)));
+                      new ByteArrayInputStream(data.consumeBytes(data.consumeInt(1, 10000))));
           provider.generateV3Certificate(
               keyPair, keyPair.getPrivate(), cert, data.consumeRemainingAsString());
-          break;
         case 2:
           provider.generateV1SelfSignedCertificate(keyPair, data.consumeRemainingAsString());
-          break;
         case 3:
           cert =
               (X509Certificate)
                   cf.generateCertificate(
-                      new ByteArrayInputStream(data.consumeBytes(data.remainingBytes() / 2)));
+                      new ByteArrayInputStream(data.consumeRemainingAsBytes()));
           provider.getCertificatePolicyList(cert);
-          break;
         case 4:
           cert =
               (X509Certificate)
                   cf.generateCertificate(
-                      new ByteArrayInputStream(data.consumeBytes(data.remainingBytes() / 2)));
+                      new ByteArrayInputStream(data.consumeRemainingAsBytes()));
           provider.getCRLDistributionPoints(cert);
-          break;
         case 5:
           Date startDate = new Date(data.consumeLong());
           Date expiryDate = new Date(data.consumeLong());
           provider.createServicesTestCertificate(
-              data.consumeString(data.remainingBytes() / 2),
+              data.consumeString(data.consumeInt(1, 10000)),
               startDate,
               expiryDate,
               keyPair,
               data.consumeRemainingAsString());
-          break;
       }
     } catch (Exception | NoSuchMethodError | ExceptionInInitializerError | NoClassDefFoundError e) {
       // Known exception and errors directly thrown from the above methods

--- a/projects/keycloak/ClientSignatureVerifierProviderFuzzer.java
+++ b/projects/keycloak/ClientSignatureVerifierProviderFuzzer.java
@@ -67,40 +67,28 @@ public class ClientSignatureVerifierProviderFuzzer {
       switch (choice) {
         case 1:
           factory = new ES256ClientSignatureVerifierProviderFactory();
-          break;
         case 2:
           factory = new ES384ClientSignatureVerifierProviderFactory();
-          break;
         case 3:
           factory = new ES512ClientSignatureVerifierProviderFactory();
-          break;
         case 4:
           factory = new HS256ClientSignatureVerifierProviderFactory();
-          break;
         case 5:
           factory = new HS384ClientSignatureVerifierProviderFactory();
-          break;
         case 6:
           factory = new HS512ClientSignatureVerifierProviderFactory();
-          break;
         case 7:
           factory = new PS256ClientSignatureVerifierProviderFactory();
-          break;
         case 8:
           factory = new PS384ClientSignatureVerifierProviderFactory();
-          break;
         case 9:
           factory = new PS512ClientSignatureVerifierProviderFactory();
-          break;
         case 10:
           factory = new RS256ClientSignatureVerifierProviderFactory();
-          break;
         case 11:
           factory = new RS384ClientSignatureVerifierProviderFactory();
-          break;
         case 12:
           factory = new RS512ClientSignatureVerifierProviderFactory();
-          break;
       }
 
       SignatureVerifierContext verifier =
@@ -108,9 +96,9 @@ public class ClientSignatureVerifierProviderFuzzer {
               .create(mockObject.getSession())
               .verifier(
                   mockObject.getClient(),
-                  new JWSInput(data.consumeString(data.remainingBytes() / 2)));
+                  new JWSInput(data.consumeString(data.consumeInt(0, 10000))));
 
-      verifier.verify(data.consumeBytes(data.remainingBytes() / 2), data.consumeRemainingAsBytes());
+      verifier.verify(data.consumeBytes(data.consumeInt(0, 10000)), data.consumeRemainingAsBytes());
     } catch (VerificationException | JWSInputException e) {
       // Known exception
     } finally {

--- a/projects/keycloak/CommonCryptoUtilsFuzzer.java
+++ b/projects/keycloak/CommonCryptoUtilsFuzzer.java
@@ -46,98 +46,76 @@ public class CommonCryptoUtilsFuzzer {
           cert =
               (X509Certificate)
                   cf.generateCertificate(
-                      new ByteArrayInputStream(data.consumeBytes(data.remainingBytes() / 2)));
+                      new ByteArrayInputStream(data.consumeBytes(data.consumeInt(0, 10000))));
           keyPair = KeyUtils.generateRsaKeyPair(2048);
           CertificateUtils.generateV3Certificate(
               keyPair, keyPair.getPrivate(), cert, data.consumeRemainingAsString());
-          break;
         case 2:
           keyPair = KeyUtils.generateRsaKeyPair(2048);
           CertificateUtils.generateV1SelfSignedCertificate(
               keyPair, data.consumeRemainingAsString());
-          break;
         case 3:
           keyPair = KeyUtils.generateRsaKeyPair(2048);
           BigInteger serial = BigInteger.valueOf(data.consumeLong());
           CertificateUtils.generateV1SelfSignedCertificate(
               keyPair, data.consumeRemainingAsString(), serial);
-          break;
         case 4:
           DerUtils.decodePrivateKey(new ByteArrayInputStream(data.consumeRemainingAsBytes()));
-          break;
         case 5:
           DerUtils.decodePrivateKey(data.consumeRemainingAsBytes());
-          break;
         case 6:
           DerUtils.decodePublicKey(
-              data.consumeBytes(data.remainingBytes() / 2), data.consumeRemainingAsString());
-          break;
+              data.consumeBytes(data.consumeInt(0, 10000)), data.consumeRemainingAsString());
         case 7:
           DerUtils.decodeCertificate(new ByteArrayInputStream(data.consumeRemainingAsBytes()));
-          break;
         case 8:
           keyPair = KeyUtils.generateRsaKeyPair(2048);
           KeyUtils.createKeyId(keyPair.getPrivate());
-          break;
         case 9:
           KeystoreUtil.loadKeyStore(
-              data.consumeString(data.remainingBytes() / 2), data.consumeRemainingAsString());
-          break;
+              data.consumeString(data.consumeInt(0, 10000)), data.consumeRemainingAsString());
         case 10:
           KeystoreUtil.loadKeyPairFromKeystore(
-              data.consumeString(data.remainingBytes() / 2),
-              data.consumeString(data.remainingBytes() / 2),
-              data.consumeString(data.remainingBytes() / 2),
-              data.consumeString(data.remainingBytes() / 2),
+              data.consumeString(data.consumeInt(0, 10000)),
+              data.consumeString(data.consumeInt(0, 10000)),
+              data.consumeString(data.consumeInt(0, 10000)),
+              data.consumeString(data.consumeInt(0, 10000)),
               data.pickValue(EnumSet.allOf(KeystoreUtil.KeystoreFormat.class)));
-          break;
         case 11:
           KeystoreUtil.getKeystoreType(
-              data.consumeString(data.remainingBytes() / 2),
-              data.consumeString(data.remainingBytes() / 2),
+              data.consumeString(data.consumeInt(0, 10000)),
+              data.consumeString(data.consumeInt(0, 10000)),
               data.consumeRemainingAsString());
-          break;
         case 12:
           PemUtils.decodeCertificate(data.consumeRemainingAsString());
-          break;
         case 13:
           PemUtils.decodePublicKey(data.consumeRemainingAsString());
-          break;
         case 14:
           PemUtils.decodePublicKey(
-              data.consumeString(data.remainingBytes() / 2), data.consumeRemainingAsString());
-          break;
+              data.consumeString(data.consumeInt(0, 10000)), data.consumeRemainingAsString());
         case 15:
           PemUtils.decodePrivateKey(data.consumeRemainingAsString());
-          break;
         case 16:
           keyPair = KeyUtils.generateRsaKeyPair(2048);
           PemUtils.encodeKey(keyPair.getPrivate());
-          break;
         case 17:
           cert =
               (X509Certificate)
                   cf.generateCertificate(
-                      new ByteArrayInputStream(data.consumeBytes(data.remainingBytes() / 2)));
+                      new ByteArrayInputStream(data.consumeBytes(data.consumeInt(0, 10000))));
           PemUtils.encodeCertificate(cert);
-          break;
         case 18:
           PemUtils.pemToDer(data.consumeRemainingAsString());
-          break;
         case 19:
           PemUtils.removeBeginEnd(data.consumeRemainingAsString());
-          break;
         case 20:
           PemUtils.addPrivateKeyBeginEnd(data.consumeRemainingAsString());
-          break;
         case 21:
           PemUtils.addRsaPrivateKeyBeginEnd(data.consumeRemainingAsString());
-          break;
         case 22:
-          String encoding = data.consumeString(data.remainingBytes() / 2);
+          String encoding = data.consumeString(data.consumeInt(0, 10000));
           String[] chain = {data.consumeRemainingAsString()};
           PemUtils.generateThumbprint(chain, encoding);
-          break;
       }
     } catch (GeneralSecurityException | RuntimeException | IOException e) {
       // Known exception

--- a/projects/keycloak/CommonUtilsFuzzer.java
+++ b/projects/keycloak/CommonUtilsFuzzer.java
@@ -32,68 +32,47 @@ public class CommonUtilsFuzzer {
       switch (choice) {
         case 1:
           Encode.encodeQueryString(data.consumeRemainingAsString());
-          break;
         case 2:
           Encode.encodePath(data.consumeRemainingAsString());
-          break;
         case 3:
           Encode.encodePathSegment(data.consumeRemainingAsString());
-          break;
         case 4:
           Encode.encodeFragment(data.consumeRemainingAsString());
-          break;
         case 5:
           Encode.encodeMatrixParam(data.consumeRemainingAsString());
-          break;
         case 6:
           Encode.encodeQueryParam(data.consumeRemainingAsString());
-          break;
         case 7:
           Encode.decodePath(data.consumeRemainingAsString());
-          break;
         case 8:
           Encode.encodePathAsIs(data.consumeRemainingAsString());
-          break;
         case 9:
           Encode.encodePathSaveEncodings(data.consumeRemainingAsString());
-          break;
         case 10:
           Encode.encodePathSegmentAsIs(data.consumeRemainingAsString());
-          break;
         case 11:
           Encode.encodePathSegmentSaveEncodings(data.consumeRemainingAsString());
-          break;
         case 12:
           Encode.encodeQueryParamAsIs(data.consumeRemainingAsString());
-          break;
         case 13:
           Encode.encodeQueryParamSaveEncodings(data.consumeRemainingAsString());
-          break;
         case 14:
           Encode.encodeFragmentAsIs(data.consumeRemainingAsString());
-          break;
         case 15:
           EnvUtil.replace(data.consumeRemainingAsString());
-          break;
         case 16:
           FindFile.findFile(data.consumeRemainingAsString());
-          break;
         case 17:
           HtmlUtils.escapeAttribute(data.consumeRemainingAsString());
-          break;
         case 18:
           Integer port = data.consumeInt(1, 65536);
           NetworkUtils.formatAddress(new InetSocketAddress(data.consumeRemainingAsString(), port));
-          break;
         case 19:
           PathHelper.replaceEnclosedCurlyBraces(data.consumeRemainingAsString());
-          break;
         case 20:
           PathHelper.recoverEnclosedCurlyBraces(data.consumeRemainingAsString());
-          break;
         case 21:
           StackUtil.getShortStackTrace(data.consumeRemainingAsString());
-          break;
       }
     } catch (RuntimeException e) {
       // Known exception

--- a/projects/keycloak/ConditionalAuthenticatorFuzzer.java
+++ b/projects/keycloak/ConditionalAuthenticatorFuzzer.java
@@ -33,25 +33,20 @@ public class ConditionalAuthenticatorFuzzer {
       switch (data.consumeInt(1, 4)) {
         case 1:
           factory = new ConditionalLoaAuthenticatorFactory();
-          break;
         case 2:
           factory = new ConditionalRoleAuthenticatorFactory();
-          break;
         case 3:
           factory = new ConditionalUserAttributeValueFactory();
-          break;
         case 4:
           factory = new ConditionalUserConfiguredAuthenticatorFactory();
-          break;
       }
 
       // Fuzz the authenticate method
-      if (factory != null) {
-        KeycloakSession session = BaseHelper.createKeycloakSession(data);
-        Authenticator authenticator = factory.create(session);
-        BaseHelper.randomizeContext(context, null, factory.getRequirementChoices());
-        authenticator.authenticate(context);
-      }
+      KeycloakSession session = BaseHelper.createKeycloakSession(data);
+      Authenticator authenticator = factory.create(session);
+      BaseHelper.randomizeContext(context, null, factory.getRequirementChoices());
+      authenticator.authenticate(context);
+      
     } catch (RuntimeException e) {
       // Known exception
     }

--- a/projects/keycloak/DefaultAuthenticationFlowsFuzzer.java
+++ b/projects/keycloak/DefaultAuthenticationFlowsFuzzer.java
@@ -33,34 +33,24 @@ public class DefaultAuthenticationFlowsFuzzer {
       switch (choice) {
         case 1:
           DefaultAuthenticationFlows.addFlows(realm);
-          break;
         case 2:
           DefaultAuthenticationFlows.migrateFlows(realm);
-          break;
         case 3:
           DefaultAuthenticationFlows.registrationFlow(realm, true);
-          break;
         case 4:
           DefaultAuthenticationFlows.browserFlow(realm, true);
-          break;
         case 5:
           DefaultAuthenticationFlows.directGrantFlow(realm, true);
-          break;
         case 6:
           DefaultAuthenticationFlows.addIdentityProviderAuthenticator(realm, string);
-          break;
         case 7:
           DefaultAuthenticationFlows.clientAuthFlow(realm);
-          break;
         case 8:
           DefaultAuthenticationFlows.firstBrokerLoginFlow(realm, true);
-          break;
         case 9:
           DefaultAuthenticationFlows.samlEcpProfile(realm);
-          break;
         case 10:
           DefaultAuthenticationFlows.dockerAuthenticationFlow(realm);
-          break;
       }
     } catch (RuntimeException e) {
       // Known exception


### PR DESCRIPTION
In general: Remove `break` at the end of a case in `switch` statements. 

Remove `null` checks before testing the target method: We want to know if this does not work and not hide it.

Rewrite some bytes and strings in the cryptoutils fuzzer to be more flexible.

cc @arthurscchan for info