### PR TITLE
Keycloak: Fix GC overhead limit exceed problem

### DIFF
--- a/projects/keycloak/AuthenticatorFuzzer.java
+++ b/projects/keycloak/AuthenticatorFuzzer.java
@@ -45,9 +45,11 @@ public class AuthenticatorFuzzer {
       }
 
       // Fuzz the authenticate method
-      authenticator.authenticate(context);  
+      authenticator.authenticate(context);
     } catch (RuntimeException e) {
       // Known exception
+    } finally {
+      BaseHelper.cleanMockObject();
     }
   }
 }

--- a/projects/keycloak/AuthzClientFuzzer.java
+++ b/projects/keycloak/AuthzClientFuzzer.java
@@ -110,6 +110,8 @@ public class AuthzClientFuzzer {
       }
     } catch (RuntimeException e) {
       // Known exception thrown directly from method above.
+    } finally {
+      BaseHelper.cleanMockObject();
     }
   }
 }

--- a/projects/keycloak/BaseHelper.java
+++ b/projects/keycloak/BaseHelper.java
@@ -112,6 +112,9 @@ import org.mockito.Mockito;
  */
 public class BaseHelper {
   private static MockKeycloakSession session;
+  private static RealmModel realm;
+  private static ClientModel client;
+  private static AuthenticationFlowContext flowContext;
 
   public static KeycloakSession createKeycloakSession(FuzzedDataProvider data) {
     if (session == null) {
@@ -131,9 +134,10 @@ public class BaseHelper {
       createKeycloakSession(data);
     }
 
-    RealmModel realm = Mockito.mock(RealmModel.class);
-
-    Mockito.doReturn(createClientModel(data)).when(realm).addClient(Mockito.any(String.class));
+    if (realm == null) {
+      realm = Mockito.mock(RealmModel.class);
+      Mockito.doReturn(createClientModel(data)).when(realm).addClient(Mockito.any(String.class));
+    }
 
     return realm;
   }
@@ -149,8 +153,10 @@ public class BaseHelper {
       Algorithm.AES
     };
 
-    ClientModel client = Mockito.mock(ClientModel.class);
-    Mockito.doReturn(data.pickValue(algorithm)).when(client).getAttribute(Mockito.any());
+    if (client == null) {
+      client = Mockito.mock(ClientModel.class);
+      Mockito.doReturn(data.pickValue(algorithm)).when(client).getAttribute(Mockito.any());
+    }
 
     return client;
   }
@@ -189,7 +195,11 @@ public class BaseHelper {
   }
 
   public static AuthenticationFlowContext createAuthenticationFlowContext(FuzzedDataProvider data) {
-    return new DefaultAuthenticationFlowContext(data);
+    if (flowContext == null) {
+      flowContext = new DefaultAuthenticationFlowContext(data);
+    }
+
+    return flowContext;
   }
 
   public static AuthenticationFlowContext randomizeContext(
@@ -209,6 +219,23 @@ public class BaseHelper {
     }
 
     return context;
+  }
+
+  public static void cleanMockObject() {
+    // Clean up mock keycloak session
+    session.dereferenceObject();
+
+    // Deference static mock object instance
+    session = null;
+    realm = null;
+    client = null;
+    flowContext = null;
+
+    // Clean up inline mocks of the mock objects
+    Mockito.framework().clearInlineMocks();
+
+    // Suggest the java garbage collector to clean up unused memory
+    System.gc();
   }
 
   protected static class DefaultScope implements Config.Scope {
@@ -463,6 +490,12 @@ public class BaseHelper {
 
     public KeycloakSession getSession() {
       return this.session;
+    }
+
+    public void dereferenceObject() {
+      providerMap = null;
+      session = null;
+      data = null;
     }
 
     private void initCredentialProvider() {

--- a/projects/keycloak/BaseHelper.java
+++ b/projects/keycloak/BaseHelper.java
@@ -223,7 +223,9 @@ public class BaseHelper {
 
   public static void cleanMockObject() {
     // Clean up mock keycloak session
-    session.dereferenceObject();
+    if (session != null) {
+      session.dereferenceObject();
+    }
 
     // Deference static mock object instance
     session = null;

--- a/projects/keycloak/BrokerAuthenticatorFuzzer.java
+++ b/projects/keycloak/BrokerAuthenticatorFuzzer.java
@@ -65,6 +65,8 @@ public class BrokerAuthenticatorFuzzer {
       authenticator.authenticate(context);
     } catch (RuntimeException e) {
       // Known exception
+    } finally {
+      BaseHelper.cleanMockObject();
     }
   }
 }

--- a/projects/keycloak/ConditionalAuthenticatorFuzzer.java
+++ b/projects/keycloak/ConditionalAuthenticatorFuzzer.java
@@ -46,9 +46,10 @@ public class ConditionalAuthenticatorFuzzer {
       Authenticator authenticator = factory.create(session);
       BaseHelper.randomizeContext(context, null, factory.getRequirementChoices());
       authenticator.authenticate(context);
-      
     } catch (RuntimeException e) {
       // Known exception
+    } finally {
+      BaseHelper.cleanMockObject();
     }
   }
 }

--- a/projects/keycloak/DefaultAuthenticationFlowsFuzzer.java
+++ b/projects/keycloak/DefaultAuthenticationFlowsFuzzer.java
@@ -54,6 +54,8 @@ public class DefaultAuthenticationFlowsFuzzer {
       }
     } catch (RuntimeException e) {
       // Known exception
+    } finally {
+      BaseHelper.cleanMockObject();
     }
   }
 }

--- a/projects/keycloak/DirectGrantAuthenticatorFuzzer.java
+++ b/projects/keycloak/DirectGrantAuthenticatorFuzzer.java
@@ -43,6 +43,8 @@ public class DirectGrantAuthenticatorFuzzer {
       authenticator.authenticate(context);
     } catch (RuntimeException e) {
       // Known exception
+    } finally {
+      BaseHelper.cleanMockObject();
     }
   }
 }

--- a/projects/keycloak/KeycloakModelUtilsFuzzer.java
+++ b/projects/keycloak/KeycloakModelUtilsFuzzer.java
@@ -99,6 +99,8 @@ public class KeycloakModelUtilsFuzzer {
       }
     } catch (RuntimeException e) {
       // Known exception
+    } finally {
+      BaseHelper.cleanMockObject();
     }
   }
 }

--- a/projects/keycloak/ResetcredAuthenticatorFuzzer.java
+++ b/projects/keycloak/ResetcredAuthenticatorFuzzer.java
@@ -45,6 +45,8 @@ public class ResetcredAuthenticatorFuzzer {
       authenticator.authenticate(context);
     } catch (RuntimeException e) {
       // Known exception
+    } finally {
+      BaseHelper.cleanMockObject();
     }
   }
 }

--- a/projects/keycloak/ValidatorFuzzer.java
+++ b/projects/keycloak/ValidatorFuzzer.java
@@ -71,6 +71,8 @@ public class ValidatorFuzzer {
       }
     } catch (RuntimeException e) {
       // Known exception
+    } finally {
+      BaseHelper.cleanMockObject();
     }
   }
 }

--- a/projects/keycloak/X509AuthenticatorFuzzer.java
+++ b/projects/keycloak/X509AuthenticatorFuzzer.java
@@ -38,6 +38,8 @@ public class X509AuthenticatorFuzzer {
       authenticator.authenticate(context);
     } catch (RuntimeException e) {
       // Known exception
+    } finally {
+      BaseHelper.cleanMockObject();
     }
   }
 }


### PR DESCRIPTION
This PR fixes the logic by cleaning up Mockito objects after use to avoid GC overhead limit exceed when cleaning those objects.