### PR TITLE
Keycloak: Catch expected IllegalStateException from invalid JWE String

### DIFF
--- a/projects/keycloak/JweFuzzer.java
+++ b/projects/keycloak/JweFuzzer.java
@@ -114,8 +114,10 @@ public class JweFuzzer {
       // Call the deserializeCEK methods from JWEEncryptionProvider objects
       achsjeProvider.deserializeCEK(keyStorage);
       agjeProvider.deserializeCEK(keyStorage);
-    } catch (JWEException | IOException | GeneralSecurityException | IllegalArgumentException e) {
+    } catch (JWEException | IOException | GeneralSecurityException e) {
       // Known exception
+    } catch (IllegalArgumentException | IllegalStateException e) {
+      // Known RuntimeException
     }
   }
 }


### PR DESCRIPTION
This PR fixes expected IllegalStateException discovered in https://issues.oss-fuzz.com/u/7/issues/371683507.