### PR TITLE
Keycloak: Fix unexpected NPE

### DIFF
--- a/projects/keycloak/TokenVerifierFuzzer.java
+++ b/projects/keycloak/TokenVerifierFuzzer.java
@@ -21,7 +21,12 @@ import org.keycloak.representations.JsonWebToken;
 public class TokenVerifierFuzzer {
   public static void fuzzerTestOneInput(FuzzedDataProvider data) {
     try {
-      TokenVerifier.create(data.consumeRemainingAsString(), JsonWebToken.class).verify();
+      TokenVerifier verifier = TokenVerifier.create(data.consumeRemainingAsString(), JsonWebToken.class);
+      if ((verifier.getHeader() == null) || (verifier.getHeader().getAlgorithm() == null)) {
+        // Malformed JsonWebToken, skipping to next iteration.
+        return;
+      }
+      verifier.verify();
     } catch (VerificationException e) {
       // Known exception
     }


### PR DESCRIPTION
This PR fixes the problem that unexpected NPE is thrown whenhandling malformed webtoken. 