### PR TITLE
Keycloak: Fix build script

### DIFF
--- a/projects/keycloak/build.sh
+++ b/projects/keycloak/build.sh
@@ -112,7 +112,8 @@ cp $SRC/BaseHelper*.class $OUT/
 for fuzzer in $(find $SRC -name '*Fuzzer.java'); do
   if [[ "$fuzzer" == *"AuthenticatorFuzzer"* ]] || [[ "$fuzzer" == *"ValidatorFuzzer"* ]] || \
   [[ "$fuzzer" == *"KeycloakUriBuilderFuzzer"* ]] || [[ "$fuzzer" == *"KeycloakModelUtilsFuzzer"* ]] || \
-  [[ "$fuzzer" == *"SamlXmlUtilFuzzer"* ]]
+  [[ "$fuzzer" == *"SamlXmlUtilFuzzer"* ]] || [[ "$fuzzer" == *"AuthzClientFuzzer"* ]] || \
+  [[ "$fuzzer" == *"DefaultAuthenticationFlowsFuzzer"* ]]
   then
     RUNTIME_CLASSPATH=$RUNTIME_CLASSPATH_DEFAULT_CRYPTO
   elif [[ "$fuzzer" == *"JweAlgorithmProviderFuzzer"* ]]


### PR DESCRIPTION
This PR fixes the build script for project Keycloak to avoid FIPS library in certain fuzzer, this helps to avoid crashing from issue in https://issues.oss-fuzz.com/u/7/issues/370107017. This PR is also needed to make the OSS-Fuzz CI in https://github.com/google/oss-fuzz/pull/12666 success.