### PR TITLE
KubeEdge: Fix viaduct path

### DIFF
--- a/projects/kubeedge/build.sh
+++ b/projects/kubeedge/build.sh
@@ -6,6 +6,7 @@ set -x
 cp $SRC/cncf-fuzzing/projects/kubeedge/lane_fuzzer.go $SRC/kubeedge/pkg/viaduct/pkg/lane/
 cd $SRC/kubeedge/pkg/viaduct
 sed '94d' -i $SRC/kubeedge/pkg/viaduct/pkg/translator/message.go
+go mod tidy && GOWORK=off go mod vendor
 compile_go_fuzzer github.com/kubeedge/kubeedge/pkg/viaduct/pkg/lane FuzzLaneReadMessage fuzz_lane_read_message
 
 cp $SRC/cncf-fuzzing/projects/kubeedge/dtmanager_fuzzer.go $SRC/kubeedge/edge/pkg/devicetwin/dtmanager/

--- a/projects/kubeedge/lane_fuzzer.go
+++ b/projects/kubeedge/lane_fuzzer.go
@@ -20,9 +20,9 @@ import (
 	fuzz "github.com/AdaLogics/go-fuzz-headers"
 	"github.com/golang/mock/gomock"
 	"github.com/kubeedge/beehive/pkg/core/model"
-	"github.com/kubeedge/viaduct/mocks"
-	"github.com/kubeedge/viaduct/pkg/packer"
-	"github.com/kubeedge/viaduct/pkg/translator"
+	"github.com/kubeedge/kubeedge/pkg/viaduct/mocks"
+	"github.com/kubeedge/kubeedge/pkg/viaduct/pkg/packer"
+	"github.com/kubeedge/kubeedge/pkg/viaduct/pkg/translator"
 )
 
 var mockFuzzStream *mocks.MockStream


### PR DESCRIPTION
KubeEdge will move viaduct path to https://github.com/kubeedge/kubeedge/tree/master/pkg in https://github.com/kubeedge/kubeedge/pull/5907, this PR fix the corresponding viaduct path.