### PR TITLE
fix: format and migration to sigs.k8s.io/yaml

### DIFF
--- a/projects/argo/diff_fuzzer.go
+++ b/projects/argo/diff_fuzzer.go
@@ -22,11 +22,11 @@ import (
 	fuzz "github.com/AdaLogics/go-fuzz-headers"
 
 	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
-	appstatecache "github.com/argoproj/argo-cd/v2/util/cache/appstate"
 	"github.com/argoproj/argo-cd/v2/util/argo/normalizers"
+	appstatecache "github.com/argoproj/argo-cd/v2/util/cache/appstate"
 
-	"github.com/ghodss/yaml"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/yaml"
 )
 
 type diffConfigParams struct {

--- a/projects/argo/events_controllers_sensor_fuzzer.go
+++ b/projects/argo/events_controllers_sensor_fuzzer.go
@@ -16,31 +16,31 @@
 package sensor
 
 import (
-        "github.com/ghodss/yaml"
-        eventbusv1alpha1 "github.com/argoproj/argo-events/pkg/apis/eventbus/v1alpha1"
-        "github.com/argoproj/argo-events/pkg/apis/sensor/v1alpha1"
-        fuzz "github.com/AdaLogics/go-fuzz-headers"
+	fuzz "github.com/AdaLogics/go-fuzz-headers"
+	eventbusv1alpha1 "github.com/argoproj/argo-events/pkg/apis/eventbus/v1alpha1"
+	"github.com/argoproj/argo-events/pkg/apis/sensor/v1alpha1"
+	"sigs.k8s.io/yaml"
 )
 
 func FuzzValidateSensor(data []byte) int {
-        f := fuzz.NewConsumer(data)
-        eventBus := &eventbusv1alpha1.EventBus{}
-        err := f.GenerateStruct(eventBus)
-        if err != nil {
-                return 0
-        }
-        content, err := f.GetBytes()
-        if err != nil {
-                return 0
-        }
-        sensor := &v1alpha1.Sensor{}
-        err = yaml.Unmarshal(content, &sensor)
-        if err != nil {
-                return 0
-        }
-        if sensor == nil {
-                return 0
-        }
-        ValidateSensor(sensor, eventBus)
-        return 1
+	f := fuzz.NewConsumer(data)
+	eventBus := &eventbusv1alpha1.EventBus{}
+	err := f.GenerateStruct(eventBus)
+	if err != nil {
+		return 0
+	}
+	content, err := f.GetBytes()
+	if err != nil {
+		return 0
+	}
+	sensor := &v1alpha1.Sensor{}
+	err = yaml.Unmarshal(content, &sensor)
+	if err != nil {
+		return 0
+	}
+	if sensor == nil {
+		return 0
+	}
+	ValidateSensor(sensor, eventBus)
+	return 1
 }

--- a/projects/cluster-api/fuzz_cluster_controller.go
+++ b/projects/cluster-api/fuzz_cluster_controller.go
@@ -1,100 +1,100 @@
 package cluster
 
 import (
-        "context"
-        "fmt"
-        "testing"
-        "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-        "sigs.k8s.io/cluster-api/internal/test/builder"
-        corev1 "k8s.io/api/core/v1"
-        "sigs.k8s.io/cluster-api/util"
-        "sigs.k8s.io/controller-runtime/pkg/reconcile"
-        "sigs.k8s.io/controller-runtime/pkg/client/fake"
-        "github.com/ghodss/yaml"
-        fuzz "github.com/AdaLogics/go-fuzz-headers"
-        clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"context"
+	"fmt"
+	"testing"
 
-        apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-        "k8s.io/apimachinery/pkg/runtime"
-        clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	fuzz "github.com/AdaLogics/go-fuzz-headers"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/cluster-api/internal/test/builder"
+	"sigs.k8s.io/cluster-api/util"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/yaml"
+
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 )
 
 var (
-        fuzzCtx = context.Background()
-        fakeSchemeForFuzzing = runtime.NewScheme()
+	fuzzCtx              = context.Background()
+	fakeSchemeForFuzzing = runtime.NewScheme()
 )
 
 func init() {
-        _ = clientgoscheme.AddToScheme(fakeSchemeForFuzzing)
-        _ = clusterv1.AddToScheme(fakeSchemeForFuzzing)
-        _ = apiextensionsv1.AddToScheme(fakeSchemeForFuzzing)
-        _ = corev1.AddToScheme(fakeSchemeForFuzzing)
+	_ = clientgoscheme.AddToScheme(fakeSchemeForFuzzing)
+	_ = clusterv1.AddToScheme(fakeSchemeForFuzzing)
+	_ = apiextensionsv1.AddToScheme(fakeSchemeForFuzzing)
+	_ = corev1.AddToScheme(fakeSchemeForFuzzing)
 }
 
 // helper function to crate an unstructured object.
 func GetUnstructured(f *fuzz.ConsumeFuzzer) (*unstructured.Unstructured, error) {
-        yamlStr, err := f.GetString()
-        if err != nil {
-                return nil, err
-        }
-        obj := make(map[string]interface{})
-        err = yaml.Unmarshal([]byte(yamlStr), &obj)
-        if err != nil {
-                return nil, err
-        }
-        return &unstructured.Unstructured{Object: obj}, nil
+	yamlStr, err := f.GetString()
+	if err != nil {
+		return nil, err
+	}
+	obj := make(map[string]interface{})
+	err = yaml.Unmarshal([]byte(yamlStr), &obj)
+	if err != nil {
+		return nil, err
+	}
+	return &unstructured.Unstructured{Object: obj}, nil
 }
 
-
 func validateUnstructured(unstr *unstructured.Unstructured) error {
-        if _, ok := unstr.Object["kind"]; !ok {
-                return fmt.Errorf("invalid unstr")
-        }
-        if _, ok := unstr.Object["apiVersion"]; !ok {
-                return fmt.Errorf("invalid unstr")
-        }
-        if _, ok := unstr.Object["spec"]; !ok {
-                return fmt.Errorf("invalid unstr")
-        }
-        if _, ok := unstr.Object["status"]; !ok {
-                return fmt.Errorf("invalid unstr")
-        }
-        return nil
+	if _, ok := unstr.Object["kind"]; !ok {
+		return fmt.Errorf("invalid unstr")
+	}
+	if _, ok := unstr.Object["apiVersion"]; !ok {
+		return fmt.Errorf("invalid unstr")
+	}
+	if _, ok := unstr.Object["spec"]; !ok {
+		return fmt.Errorf("invalid unstr")
+	}
+	if _, ok := unstr.Object["status"]; !ok {
+		return fmt.Errorf("invalid unstr")
+	}
+	return nil
 }
 
 func FuzzClusterReconcile(f *testing.F) {
-        f.Fuzz(func (t *testing.T, data []byte){
-                fdp := fuzz.NewConsumer(data)
-                unstr, err := GetUnstructured(fdp)
-                if err != nil {
-                        return
-                }
-                err = validateUnstructured(unstr)
-                if err != nil {
-                        return
-                }
-                cluster := &clusterv1.Cluster{}
-                err = fdp.GenerateStruct(cluster)
-                if err != nil {
-                        return
-                }
-                node := &corev1.Node{}
-                err = fdp.GenerateStruct(node)
-                if err != nil {
-                        return
-                }
-                clientFake := fake.NewClientBuilder().WithScheme(fakeSchemeForFuzzing).WithObjects(
-                        cluster,
-                        node,
-                        unstr,
-                        builder.GenericInfrastructureMachineCRD.DeepCopy(),
-                ).Build()
-                r := &Reconciler{
-                        Client:    clientFake,
-                        APIReader:    clientFake,
-                }
+	f.Fuzz(func(t *testing.T, data []byte) {
+		fdp := fuzz.NewConsumer(data)
+		unstr, err := GetUnstructured(fdp)
+		if err != nil {
+			return
+		}
+		err = validateUnstructured(unstr)
+		if err != nil {
+			return
+		}
+		cluster := &clusterv1.Cluster{}
+		err = fdp.GenerateStruct(cluster)
+		if err != nil {
+			return
+		}
+		node := &corev1.Node{}
+		err = fdp.GenerateStruct(node)
+		if err != nil {
+			return
+		}
+		clientFake := fake.NewClientBuilder().WithScheme(fakeSchemeForFuzzing).WithObjects(
+			cluster,
+			node,
+			unstr,
+			builder.GenericInfrastructureMachineCRD.DeepCopy(),
+		).Build()
+		r := &Reconciler{
+			Client:    clientFake,
+			APIReader: clientFake,
+		}
 
-                r.Reconcile(fuzzCtx, reconcile.Request{NamespacedName: util.ObjectKey(cluster)})
-                
-        })
+		r.Reconcile(fuzzCtx, reconcile.Request{NamespacedName: util.ObjectKey(cluster)})
+
+	})
 }

--- a/projects/cluster-api/fuzz_clusterclass_controller.go
+++ b/projects/cluster-api/fuzz_clusterclass_controller.go
@@ -1,98 +1,98 @@
 package clusterclass
 
 import (
-        "context"
-        "fmt"
-        "testing"
-        "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-        "sigs.k8s.io/cluster-api/internal/test/builder"
-        corev1 "k8s.io/api/core/v1"
-        "sigs.k8s.io/cluster-api/util"
-        "sigs.k8s.io/controller-runtime/pkg/reconcile"
-        "sigs.k8s.io/controller-runtime/pkg/client/fake"
-        "github.com/ghodss/yaml"
-        fuzz "github.com/AdaLogics/go-fuzz-headers"
-        clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"context"
+	"fmt"
+	"testing"
 
-        apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-        "k8s.io/apimachinery/pkg/runtime"
-        clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	fuzz "github.com/AdaLogics/go-fuzz-headers"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/cluster-api/internal/test/builder"
+	"sigs.k8s.io/cluster-api/util"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/yaml"
+
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 )
 
 var (
-        fuzzCtx = context.Background()
-        fakeSchemeForFuzzing = runtime.NewScheme()
+	fuzzCtx              = context.Background()
+	fakeSchemeForFuzzing = runtime.NewScheme()
 )
 
 func init() {
-        _ = clientgoscheme.AddToScheme(fakeSchemeForFuzzing)
-        _ = clusterv1.AddToScheme(fakeSchemeForFuzzing)
-        _ = apiextensionsv1.AddToScheme(fakeSchemeForFuzzing)
-        _ = corev1.AddToScheme(fakeSchemeForFuzzing)
+	_ = clientgoscheme.AddToScheme(fakeSchemeForFuzzing)
+	_ = clusterv1.AddToScheme(fakeSchemeForFuzzing)
+	_ = apiextensionsv1.AddToScheme(fakeSchemeForFuzzing)
+	_ = corev1.AddToScheme(fakeSchemeForFuzzing)
 }
 
 // helper function to crate an unstructured object.
 func GetUnstructured(f *fuzz.ConsumeFuzzer) (*unstructured.Unstructured, error) {
-        yamlStr, err := f.GetString()
-        if err != nil {
-                return nil, err
-        }
-        obj := make(map[string]interface{})
-        err = yaml.Unmarshal([]byte(yamlStr), &obj)
-        if err != nil {
-                return nil, err
-        }
-        return &unstructured.Unstructured{Object: obj}, nil
+	yamlStr, err := f.GetString()
+	if err != nil {
+		return nil, err
+	}
+	obj := make(map[string]interface{})
+	err = yaml.Unmarshal([]byte(yamlStr), &obj)
+	if err != nil {
+		return nil, err
+	}
+	return &unstructured.Unstructured{Object: obj}, nil
 }
 
-
 func validateUnstructured(unstr *unstructured.Unstructured) error {
-        if _, ok := unstr.Object["kind"]; !ok {
-                return fmt.Errorf("invalid unstr")
-        }
-        if _, ok := unstr.Object["apiVersion"]; !ok {
-                return fmt.Errorf("invalid unstr")
-        }
-        if _, ok := unstr.Object["spec"]; !ok {
-                return fmt.Errorf("invalid unstr")
-        }
-        if _, ok := unstr.Object["status"]; !ok {
-                return fmt.Errorf("invalid unstr")
-        }
-        return nil
+	if _, ok := unstr.Object["kind"]; !ok {
+		return fmt.Errorf("invalid unstr")
+	}
+	if _, ok := unstr.Object["apiVersion"]; !ok {
+		return fmt.Errorf("invalid unstr")
+	}
+	if _, ok := unstr.Object["spec"]; !ok {
+		return fmt.Errorf("invalid unstr")
+	}
+	if _, ok := unstr.Object["status"]; !ok {
+		return fmt.Errorf("invalid unstr")
+	}
+	return nil
 }
 
 func FuzzClusterClassReconcile(f *testing.F) {
-        f.Fuzz(func (t *testing.T, data []byte){
-                fdp := fuzz.NewConsumer(data)
-                unstr, err := GetUnstructured(fdp)
-                if err != nil {
-                        return
-                }
-                err = validateUnstructured(unstr)
-                if err != nil {
-                        return
-                }
-                cluster := &clusterv1.ClusterClass{}
-                err = fdp.GenerateStruct(cluster)
-                if err != nil {
-                        return
-                }
-                node := &corev1.Node{}
-                err = fdp.GenerateStruct(node)
-                if err != nil {
-                        return
-                }
-                clientFake := fake.NewClientBuilder().WithScheme(fakeSchemeForFuzzing).WithObjects(
-                        cluster,
-                        node,
-                        unstr,
-                        builder.GenericInfrastructureMachineCRD.DeepCopy(),
-                ).Build()
-                r := &Reconciler{
-                        Client:    clientFake,
-                }
+	f.Fuzz(func(t *testing.T, data []byte) {
+		fdp := fuzz.NewConsumer(data)
+		unstr, err := GetUnstructured(fdp)
+		if err != nil {
+			return
+		}
+		err = validateUnstructured(unstr)
+		if err != nil {
+			return
+		}
+		cluster := &clusterv1.ClusterClass{}
+		err = fdp.GenerateStruct(cluster)
+		if err != nil {
+			return
+		}
+		node := &corev1.Node{}
+		err = fdp.GenerateStruct(node)
+		if err != nil {
+			return
+		}
+		clientFake := fake.NewClientBuilder().WithScheme(fakeSchemeForFuzzing).WithObjects(
+			cluster,
+			node,
+			unstr,
+			builder.GenericInfrastructureMachineCRD.DeepCopy(),
+		).Build()
+		r := &Reconciler{
+			Client: clientFake,
+		}
 
-                r.Reconcile(fuzzCtx, reconcile.Request{NamespacedName: util.ObjectKey(cluster)})
-        })
+		r.Reconcile(fuzzCtx, reconcile.Request{NamespacedName: util.ObjectKey(cluster)})
+	})
 }

--- a/projects/cluster-api/fuzz_machine_controller.go
+++ b/projects/cluster-api/fuzz_machine_controller.go
@@ -1,99 +1,99 @@
 package machine
 
 import (
-        "context"
-        "fmt"
-        "testing"
-        "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-        "sigs.k8s.io/cluster-api/internal/test/builder"
-        corev1 "k8s.io/api/core/v1"
-        "sigs.k8s.io/cluster-api/util"
-        "sigs.k8s.io/controller-runtime/pkg/reconcile"
-        "sigs.k8s.io/controller-runtime/pkg/client/fake"
-        "github.com/ghodss/yaml"
-        fuzz "github.com/AdaLogics/go-fuzz-headers"
-        clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"context"
+	"fmt"
+	"testing"
 
-        apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-        "k8s.io/apimachinery/pkg/runtime"
-        clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	fuzz "github.com/AdaLogics/go-fuzz-headers"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/cluster-api/internal/test/builder"
+	"sigs.k8s.io/cluster-api/util"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/yaml"
+
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 )
 
 var (
-        fuzzCtx = context.Background()
-        fakeSchemeForFuzzing = runtime.NewScheme()
+	fuzzCtx              = context.Background()
+	fakeSchemeForFuzzing = runtime.NewScheme()
 )
 
 func init() {
-        _ = clientgoscheme.AddToScheme(fakeSchemeForFuzzing)
-        _ = clusterv1.AddToScheme(fakeSchemeForFuzzing)
-        _ = apiextensionsv1.AddToScheme(fakeSchemeForFuzzing)
-        _ = corev1.AddToScheme(fakeSchemeForFuzzing)
+	_ = clientgoscheme.AddToScheme(fakeSchemeForFuzzing)
+	_ = clusterv1.AddToScheme(fakeSchemeForFuzzing)
+	_ = apiextensionsv1.AddToScheme(fakeSchemeForFuzzing)
+	_ = corev1.AddToScheme(fakeSchemeForFuzzing)
 }
 
 // helper function to crate an unstructured object.
 func GetUnstructured(f *fuzz.ConsumeFuzzer) (*unstructured.Unstructured, error) {
-        yamlStr, err := f.GetString()
-        if err != nil {
-                return nil, err
-        }
-        obj := make(map[string]interface{})
-        err = yaml.Unmarshal([]byte(yamlStr), &obj)
-        if err != nil {
-                return nil, err
-        }
-        return &unstructured.Unstructured{Object: obj}, nil
+	yamlStr, err := f.GetString()
+	if err != nil {
+		return nil, err
+	}
+	obj := make(map[string]interface{})
+	err = yaml.Unmarshal([]byte(yamlStr), &obj)
+	if err != nil {
+		return nil, err
+	}
+	return &unstructured.Unstructured{Object: obj}, nil
 }
 
-
 func validateUnstructured(unstr *unstructured.Unstructured) error {
-        if _, ok := unstr.Object["kind"]; !ok {
-                return fmt.Errorf("invalid unstr")
-        }
-        if _, ok := unstr.Object["apiVersion"]; !ok {
-                return fmt.Errorf("invalid unstr")
-        }
-        if _, ok := unstr.Object["spec"]; !ok {
-                return fmt.Errorf("invalid unstr")
-        }
-        if _, ok := unstr.Object["status"]; !ok {
-                return fmt.Errorf("invalid unstr")
-        }
-        return nil
+	if _, ok := unstr.Object["kind"]; !ok {
+		return fmt.Errorf("invalid unstr")
+	}
+	if _, ok := unstr.Object["apiVersion"]; !ok {
+		return fmt.Errorf("invalid unstr")
+	}
+	if _, ok := unstr.Object["spec"]; !ok {
+		return fmt.Errorf("invalid unstr")
+	}
+	if _, ok := unstr.Object["status"]; !ok {
+		return fmt.Errorf("invalid unstr")
+	}
+	return nil
 }
 
 func FuzzMachineReconcile(f *testing.F) {
-        f.Fuzz(func (t *testing.T, data []byte){
-                fdp := fuzz.NewConsumer(data)
-                unstr, err := GetUnstructured(fdp)
-                if err != nil {
-                        return
-                }
-                err = validateUnstructured(unstr)
-                if err != nil {
-                        return
-                }
-                cluster := &clusterv1.Machine{}
-                err = fdp.GenerateStruct(cluster)
-                if err != nil {
-                        return
-                }
-                node := &corev1.Node{}
-                err = fdp.GenerateStruct(node)
-                if err != nil {
-                        return
-                }
-                clientFake := fake.NewClientBuilder().WithScheme(fakeSchemeForFuzzing).WithObjects(
-                        cluster,
-                        node,
-                        unstr,
-                        builder.GenericInfrastructureMachineCRD.DeepCopy(),
-                ).Build()
-                r := &Reconciler{
-                        Client:    clientFake,
-                        APIReader: clientFake,
-                }
+	f.Fuzz(func(t *testing.T, data []byte) {
+		fdp := fuzz.NewConsumer(data)
+		unstr, err := GetUnstructured(fdp)
+		if err != nil {
+			return
+		}
+		err = validateUnstructured(unstr)
+		if err != nil {
+			return
+		}
+		cluster := &clusterv1.Machine{}
+		err = fdp.GenerateStruct(cluster)
+		if err != nil {
+			return
+		}
+		node := &corev1.Node{}
+		err = fdp.GenerateStruct(node)
+		if err != nil {
+			return
+		}
+		clientFake := fake.NewClientBuilder().WithScheme(fakeSchemeForFuzzing).WithObjects(
+			cluster,
+			node,
+			unstr,
+			builder.GenericInfrastructureMachineCRD.DeepCopy(),
+		).Build()
+		r := &Reconciler{
+			Client:    clientFake,
+			APIReader: clientFake,
+		}
 
-                r.Reconcile(fuzzCtx, reconcile.Request{NamespacedName: util.ObjectKey(cluster)})
-        })
+		r.Reconcile(fuzzCtx, reconcile.Request{NamespacedName: util.ObjectKey(cluster)})
+	})
 }

--- a/projects/cluster-api/fuzz_machinedeployment_controller.go
+++ b/projects/cluster-api/fuzz_machinedeployment_controller.go
@@ -1,99 +1,99 @@
 package machinedeployment
 
 import (
-        "context"
-        "fmt"
-        "testing"
-        "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-        "sigs.k8s.io/cluster-api/internal/test/builder"
-        corev1 "k8s.io/api/core/v1"
-        "sigs.k8s.io/cluster-api/util"
-        "sigs.k8s.io/controller-runtime/pkg/reconcile"
-        "sigs.k8s.io/controller-runtime/pkg/client/fake"
-        "github.com/ghodss/yaml"
-        fuzz "github.com/AdaLogics/go-fuzz-headers"
-        clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"context"
+	"fmt"
+	"testing"
 
-        apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-        "k8s.io/apimachinery/pkg/runtime"
-        clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	fuzz "github.com/AdaLogics/go-fuzz-headers"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/cluster-api/internal/test/builder"
+	"sigs.k8s.io/cluster-api/util"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/yaml"
+
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 )
 
 var (
-        fuzzCtx = context.Background()
-        fakeSchemeForFuzzing = runtime.NewScheme()
+	fuzzCtx              = context.Background()
+	fakeSchemeForFuzzing = runtime.NewScheme()
 )
 
 func init() {
-        _ = clientgoscheme.AddToScheme(fakeSchemeForFuzzing)
-        _ = clusterv1.AddToScheme(fakeSchemeForFuzzing)
-        _ = apiextensionsv1.AddToScheme(fakeSchemeForFuzzing)
-        _ = corev1.AddToScheme(fakeSchemeForFuzzing)
+	_ = clientgoscheme.AddToScheme(fakeSchemeForFuzzing)
+	_ = clusterv1.AddToScheme(fakeSchemeForFuzzing)
+	_ = apiextensionsv1.AddToScheme(fakeSchemeForFuzzing)
+	_ = corev1.AddToScheme(fakeSchemeForFuzzing)
 }
 
 // helper function to crate an unstructured object.
 func GetUnstructured(f *fuzz.ConsumeFuzzer) (*unstructured.Unstructured, error) {
-        yamlStr, err := f.GetString()
-        if err != nil {
-                return nil, err
-        }
-        obj := make(map[string]interface{})
-        err = yaml.Unmarshal([]byte(yamlStr), &obj)
-        if err != nil {
-                return nil, err
-        }
-        return &unstructured.Unstructured{Object: obj}, nil
+	yamlStr, err := f.GetString()
+	if err != nil {
+		return nil, err
+	}
+	obj := make(map[string]interface{})
+	err = yaml.Unmarshal([]byte(yamlStr), &obj)
+	if err != nil {
+		return nil, err
+	}
+	return &unstructured.Unstructured{Object: obj}, nil
 }
 
-
 func validateUnstructured(unstr *unstructured.Unstructured) error {
-        if _, ok := unstr.Object["kind"]; !ok {
-                return fmt.Errorf("invalid unstr")
-        }
-        if _, ok := unstr.Object["apiVersion"]; !ok {
-                return fmt.Errorf("invalid unstr")
-        }
-        if _, ok := unstr.Object["spec"]; !ok {
-                return fmt.Errorf("invalid unstr")
-        }
-        if _, ok := unstr.Object["status"]; !ok {
-                return fmt.Errorf("invalid unstr")
-        }
-        return nil
+	if _, ok := unstr.Object["kind"]; !ok {
+		return fmt.Errorf("invalid unstr")
+	}
+	if _, ok := unstr.Object["apiVersion"]; !ok {
+		return fmt.Errorf("invalid unstr")
+	}
+	if _, ok := unstr.Object["spec"]; !ok {
+		return fmt.Errorf("invalid unstr")
+	}
+	if _, ok := unstr.Object["status"]; !ok {
+		return fmt.Errorf("invalid unstr")
+	}
+	return nil
 }
 
 func FuzzMachineDeploymentReconcile(f *testing.F) {
-        f.Fuzz(func (t *testing.T, data []byte){
-                fdp := fuzz.NewConsumer(data)
-                unstr, err := GetUnstructured(fdp)
-                if err != nil {
-                        return
-                }
-                err = validateUnstructured(unstr)
-                if err != nil {
-                        return
-                }
-                cluster := &clusterv1.MachineDeployment{}
-                err = fdp.GenerateStruct(cluster)
-                if err != nil {
-                        return
-                }
-                node := &corev1.Node{}
-                err = fdp.GenerateStruct(node)
-                if err != nil {
-                        return
-                }
-                clientFake := fake.NewClientBuilder().WithScheme(fakeSchemeForFuzzing).WithObjects(
-                        cluster,
-                        node,
-                        node,
-                        builder.GenericInfrastructureMachineCRD.DeepCopy(),
-                ).Build()
-                r := &Reconciler{
-                        Client:    clientFake,
-                        APIReader: clientFake,
-                }
+	f.Fuzz(func(t *testing.T, data []byte) {
+		fdp := fuzz.NewConsumer(data)
+		unstr, err := GetUnstructured(fdp)
+		if err != nil {
+			return
+		}
+		err = validateUnstructured(unstr)
+		if err != nil {
+			return
+		}
+		cluster := &clusterv1.MachineDeployment{}
+		err = fdp.GenerateStruct(cluster)
+		if err != nil {
+			return
+		}
+		node := &corev1.Node{}
+		err = fdp.GenerateStruct(node)
+		if err != nil {
+			return
+		}
+		clientFake := fake.NewClientBuilder().WithScheme(fakeSchemeForFuzzing).WithObjects(
+			cluster,
+			node,
+			node,
+			builder.GenericInfrastructureMachineCRD.DeepCopy(),
+		).Build()
+		r := &Reconciler{
+			Client:    clientFake,
+			APIReader: clientFake,
+		}
 
-                r.Reconcile(fuzzCtx, reconcile.Request{NamespacedName: util.ObjectKey(cluster)})
-        })
+		r.Reconcile(fuzzCtx, reconcile.Request{NamespacedName: util.ObjectKey(cluster)})
+	})
 }

--- a/projects/cluster-api/fuzz_machinehealthcheck_controller.go
+++ b/projects/cluster-api/fuzz_machinehealthcheck_controller.go
@@ -1,98 +1,98 @@
 package machinehealthcheck
 
 import (
-        "context"
-        "fmt"
-        "testing"
-        "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-        "sigs.k8s.io/cluster-api/internal/test/builder"
-        corev1 "k8s.io/api/core/v1"
-        "sigs.k8s.io/cluster-api/util"
-        "sigs.k8s.io/controller-runtime/pkg/reconcile"
-        "sigs.k8s.io/controller-runtime/pkg/client/fake"
-        "github.com/ghodss/yaml"
-        fuzz "github.com/AdaLogics/go-fuzz-headers"
-        clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"context"
+	"fmt"
+	"testing"
 
-        apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-        "k8s.io/apimachinery/pkg/runtime"
-        clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	fuzz "github.com/AdaLogics/go-fuzz-headers"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/cluster-api/internal/test/builder"
+	"sigs.k8s.io/cluster-api/util"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/yaml"
+
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 )
 
 var (
-        fuzzCtx = context.Background()
-        fakeSchemeForFuzzing = runtime.NewScheme()
+	fuzzCtx              = context.Background()
+	fakeSchemeForFuzzing = runtime.NewScheme()
 )
 
 func init() {
-        _ = clientgoscheme.AddToScheme(fakeSchemeForFuzzing)
-        _ = clusterv1.AddToScheme(fakeSchemeForFuzzing)
-        _ = apiextensionsv1.AddToScheme(fakeSchemeForFuzzing)
-        _ = corev1.AddToScheme(fakeSchemeForFuzzing)
+	_ = clientgoscheme.AddToScheme(fakeSchemeForFuzzing)
+	_ = clusterv1.AddToScheme(fakeSchemeForFuzzing)
+	_ = apiextensionsv1.AddToScheme(fakeSchemeForFuzzing)
+	_ = corev1.AddToScheme(fakeSchemeForFuzzing)
 }
 
 // helper function to crate an unstructured object.
 func GetUnstructured(f *fuzz.ConsumeFuzzer) (*unstructured.Unstructured, error) {
-        yamlStr, err := f.GetString()
-        if err != nil {
-                return nil, err
-        }
-        obj := make(map[string]interface{})
-        err = yaml.Unmarshal([]byte(yamlStr), &obj)
-        if err != nil {
-                return nil, err
-        }
-        return &unstructured.Unstructured{Object: obj}, nil
+	yamlStr, err := f.GetString()
+	if err != nil {
+		return nil, err
+	}
+	obj := make(map[string]interface{})
+	err = yaml.Unmarshal([]byte(yamlStr), &obj)
+	if err != nil {
+		return nil, err
+	}
+	return &unstructured.Unstructured{Object: obj}, nil
 }
 
-
 func validateUnstructured(unstr *unstructured.Unstructured) error {
-        if _, ok := unstr.Object["kind"]; !ok {
-                return fmt.Errorf("invalid unstr")
-        }
-        if _, ok := unstr.Object["apiVersion"]; !ok {
-                return fmt.Errorf("invalid unstr")
-        }
-        if _, ok := unstr.Object["spec"]; !ok {
-                return fmt.Errorf("invalid unstr")
-        }
-        if _, ok := unstr.Object["status"]; !ok {
-                return fmt.Errorf("invalid unstr")
-        }
-        return nil
+	if _, ok := unstr.Object["kind"]; !ok {
+		return fmt.Errorf("invalid unstr")
+	}
+	if _, ok := unstr.Object["apiVersion"]; !ok {
+		return fmt.Errorf("invalid unstr")
+	}
+	if _, ok := unstr.Object["spec"]; !ok {
+		return fmt.Errorf("invalid unstr")
+	}
+	if _, ok := unstr.Object["status"]; !ok {
+		return fmt.Errorf("invalid unstr")
+	}
+	return nil
 }
 
 func FuzzMachineHealthCheckReconcile(f *testing.F) {
-        f.Fuzz(func (t *testing.T, data []byte){
-                fdp := fuzz.NewConsumer(data)
-                unstr, err := GetUnstructured(fdp)
-                if err != nil {
-                        return
-                }
-                err = validateUnstructured(unstr)
-                if err != nil {
-                        return
-                }
-                mhc := &clusterv1.MachineHealthCheck{}
-                err = fdp.GenerateStruct(mhc)
-                if err != nil {
-                        return
-                }
-                node := &corev1.Node{}
-                err = fdp.GenerateStruct(node)
-                if err != nil {
-                        return
-                }
-                clientFake := fake.NewClientBuilder().WithScheme(fakeSchemeForFuzzing).WithObjects(
-                        mhc,
-                        node,
-                        unstr,
-                        builder.GenericInfrastructureMachineCRD.DeepCopy(),
-                ).Build()
-                r := &Reconciler{
-                        Client:    clientFake,
-                }
+	f.Fuzz(func(t *testing.T, data []byte) {
+		fdp := fuzz.NewConsumer(data)
+		unstr, err := GetUnstructured(fdp)
+		if err != nil {
+			return
+		}
+		err = validateUnstructured(unstr)
+		if err != nil {
+			return
+		}
+		mhc := &clusterv1.MachineHealthCheck{}
+		err = fdp.GenerateStruct(mhc)
+		if err != nil {
+			return
+		}
+		node := &corev1.Node{}
+		err = fdp.GenerateStruct(node)
+		if err != nil {
+			return
+		}
+		clientFake := fake.NewClientBuilder().WithScheme(fakeSchemeForFuzzing).WithObjects(
+			mhc,
+			node,
+			unstr,
+			builder.GenericInfrastructureMachineCRD.DeepCopy(),
+		).Build()
+		r := &Reconciler{
+			Client: clientFake,
+		}
 
-                r.Reconcile(fuzzCtx, reconcile.Request{NamespacedName: util.ObjectKey(mhc)})
-        })
+		r.Reconcile(fuzzCtx, reconcile.Request{NamespacedName: util.ObjectKey(mhc)})
+	})
 }

--- a/projects/cluster-api/fuzz_machineset_controller.go
+++ b/projects/cluster-api/fuzz_machineset_controller.go
@@ -1,99 +1,99 @@
 package machineset
 
 import (
-        "context"
-        "fmt"
-        "testing"
-        "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-        "sigs.k8s.io/cluster-api/internal/test/builder"
-        corev1 "k8s.io/api/core/v1"
-        "sigs.k8s.io/cluster-api/util"
-        "sigs.k8s.io/controller-runtime/pkg/reconcile"
-        "sigs.k8s.io/controller-runtime/pkg/client/fake"
-        "github.com/ghodss/yaml"
-        fuzz "github.com/AdaLogics/go-fuzz-headers"
-        clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"context"
+	"fmt"
+	"testing"
 
-        apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-        "k8s.io/apimachinery/pkg/runtime"
-        clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	fuzz "github.com/AdaLogics/go-fuzz-headers"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/cluster-api/internal/test/builder"
+	"sigs.k8s.io/cluster-api/util"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/yaml"
+
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 )
 
 var (
-        fuzzCtx = context.Background()
-        fakeSchemeForFuzzing = runtime.NewScheme()
+	fuzzCtx              = context.Background()
+	fakeSchemeForFuzzing = runtime.NewScheme()
 )
 
 func init() {
-        _ = clientgoscheme.AddToScheme(fakeSchemeForFuzzing)
-        _ = clusterv1.AddToScheme(fakeSchemeForFuzzing)
-        _ = apiextensionsv1.AddToScheme(fakeSchemeForFuzzing)
-        _ = corev1.AddToScheme(fakeSchemeForFuzzing)
+	_ = clientgoscheme.AddToScheme(fakeSchemeForFuzzing)
+	_ = clusterv1.AddToScheme(fakeSchemeForFuzzing)
+	_ = apiextensionsv1.AddToScheme(fakeSchemeForFuzzing)
+	_ = corev1.AddToScheme(fakeSchemeForFuzzing)
 }
 
 // helper function to crate an unstructured object.
 func GetUnstructured(f *fuzz.ConsumeFuzzer) (*unstructured.Unstructured, error) {
-        yamlStr, err := f.GetString()
-        if err != nil {
-                return nil, err
-        }
-        obj := make(map[string]interface{})
-        err = yaml.Unmarshal([]byte(yamlStr), &obj)
-        if err != nil {
-                return nil, err
-        }
-        return &unstructured.Unstructured{Object: obj}, nil
+	yamlStr, err := f.GetString()
+	if err != nil {
+		return nil, err
+	}
+	obj := make(map[string]interface{})
+	err = yaml.Unmarshal([]byte(yamlStr), &obj)
+	if err != nil {
+		return nil, err
+	}
+	return &unstructured.Unstructured{Object: obj}, nil
 }
 
-
 func validateUnstructured(unstr *unstructured.Unstructured) error {
-        if _, ok := unstr.Object["kind"]; !ok {
-                return fmt.Errorf("invalid unstr")
-        }
-        if _, ok := unstr.Object["apiVersion"]; !ok {
-                return fmt.Errorf("invalid unstr")
-        }
-        if _, ok := unstr.Object["spec"]; !ok {
-                return fmt.Errorf("invalid unstr")
-        }
-        if _, ok := unstr.Object["status"]; !ok {
-                return fmt.Errorf("invalid unstr")
-        }
-        return nil
+	if _, ok := unstr.Object["kind"]; !ok {
+		return fmt.Errorf("invalid unstr")
+	}
+	if _, ok := unstr.Object["apiVersion"]; !ok {
+		return fmt.Errorf("invalid unstr")
+	}
+	if _, ok := unstr.Object["spec"]; !ok {
+		return fmt.Errorf("invalid unstr")
+	}
+	if _, ok := unstr.Object["status"]; !ok {
+		return fmt.Errorf("invalid unstr")
+	}
+	return nil
 }
 
 func FuzzMachinesetReconcile(f *testing.F) {
-        f.Fuzz(func (t *testing.T, data []byte){
-                fdp := fuzz.NewConsumer(data)
-                unstr, err := GetUnstructured(fdp)
-                if err != nil {
-                        return
-                }
-                err = validateUnstructured(unstr)
-                if err != nil {
-                        return
-                }
-                machineset := &clusterv1.MachineSet{}
-                err = fdp.GenerateStruct(machineset)
-                if err != nil {
-                        return
-                }
-                node := &corev1.Node{}
-                err = fdp.GenerateStruct(node)
-                if err != nil {
-                        return
-                }
-                clientFake := fake.NewClientBuilder().WithScheme(fakeSchemeForFuzzing).WithObjects(
-                        machineset,
-                        node,
-                        unstr,
-                        builder.GenericInfrastructureMachineCRD.DeepCopy(),
-                ).Build()
-                r := &Reconciler{
-                        Client:    clientFake,
-                        APIReader: clientFake,
-                }
+	f.Fuzz(func(t *testing.T, data []byte) {
+		fdp := fuzz.NewConsumer(data)
+		unstr, err := GetUnstructured(fdp)
+		if err != nil {
+			return
+		}
+		err = validateUnstructured(unstr)
+		if err != nil {
+			return
+		}
+		machineset := &clusterv1.MachineSet{}
+		err = fdp.GenerateStruct(machineset)
+		if err != nil {
+			return
+		}
+		node := &corev1.Node{}
+		err = fdp.GenerateStruct(node)
+		if err != nil {
+			return
+		}
+		clientFake := fake.NewClientBuilder().WithScheme(fakeSchemeForFuzzing).WithObjects(
+			machineset,
+			node,
+			unstr,
+			builder.GenericInfrastructureMachineCRD.DeepCopy(),
+		).Build()
+		r := &Reconciler{
+			Client:    clientFake,
+			APIReader: clientFake,
+		}
 
-                r.Reconcile(fuzzCtx, reconcile.Request{NamespacedName: util.ObjectKey(machineset)})
-        })
+		r.Reconcile(fuzzCtx, reconcile.Request{NamespacedName: util.ObjectKey(machineset)})
+	})
 }

--- a/projects/cluster-api/fuzz_topology_cluster_reconciler.go
+++ b/projects/cluster-api/fuzz_topology_cluster_reconciler.go
@@ -20,9 +20,10 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/ghodss/yaml"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/yaml"
+
 	//ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -46,7 +47,7 @@ var (
 	fakeSchemeForFuzzing = runtime.NewScheme()
 	//env                  *envtest.Environment
 	//ctx                  = ctrl.SetupSignalHandler()
-	fuzzCtx     = context.Background()
+	fuzzCtx = context.Background()
 	initter sync.Once
 )
 
@@ -98,7 +99,7 @@ func validateUnstructured(unstr *unstructured.Unstructured) error {
 }
 
 func FuzzClusterReconcile(f *testing.F) {
-    f.Fuzz(func (t *testing.T, data []byte){
+	f.Fuzz(func(t *testing.T, data []byte) {
 		fdp := fuzz.NewConsumer(data)
 		unstr, err := GetUnstructured(fdp)
 		if err != nil {


### PR DESCRIPTION
This pull request migrates to usage of sigs.k8s.io, as the unmaintained github.com/ghodss/yaml could pose as a target for dependency vulnerabilities. 

Additionally, formatted imports.