### PR TITLE
Fix Kubernetes fuzzers that are failing

### DIFF
--- a/projects/kubernetes/validation_fuzzer.go
+++ b/projects/kubernetes/validation_fuzzer.go
@@ -17,6 +17,7 @@ package fuzzing
 
 import (
 	"context"
+
 	fuzz "github.com/AdaLogics/go-fuzz-headers"
 
 	v1 "k8s.io/api/core/v1"
@@ -565,7 +566,12 @@ func FuzzValidateHorizontalPodAutoscaler(data []byte) int {
 	if err != nil {
 		return 0
 	}
-	if errs := autoscalingValidation.ValidateHorizontalPodAutoscaler(autoscaler); len(errs) > 0 {
+	opts := &autoscalingValidation.HorizontalPodAutoscalerSpecValidationOptions{}
+	err = f.GenerateStruct(opts)
+	if err != nil {
+		return 0
+	}
+	if errs := autoscalingValidation.ValidateHorizontalPodAutoscaler(autoscaler, *opts); len(errs) > 0 {
 		for _, err := range errs {
 			_ = err
 			//fmt.Println(err)
@@ -587,7 +593,12 @@ func FuzzValidateHorizontalPodAutoscalerUpdate(data []byte) int {
 	if err != nil {
 		return 0
 	}
-	if errs := autoscalingValidation.ValidateHorizontalPodAutoscalerUpdate(autoscaler1, autoscaler2); len(errs) > 0 {
+	opts := &autoscalingValidation.HorizontalPodAutoscalerSpecValidationOptions{}
+	err = f.GenerateStruct(opts)
+	if err != nil {
+		return 0
+	}
+	if errs := autoscalingValidation.ValidateHorizontalPodAutoscalerUpdate(autoscaler1, autoscaler2, *opts); len(errs) > 0 {
 		for _, err := range errs {
 			_ = err
 			//fmt.Println(err)


### PR DESCRIPTION
Hi everyone,

During the Security Audit of Kubernetes Subprojects, we noticed that the current build of Kubernetes fuzzers on OSS-Fuzz is failing. [1]

In particular, for `roundtrip.go` Kubernetes deprecated the use of google's `go-fuzz` library in favor of `sigs.k8s.io/randfill`.
While for `validation_fuzzer.go` the signature of some API changed on Kubernetes side.

This PR fixes both of them, restoring a successful fuzzers build.

[1] https://introspector.oss-fuzz.com/project-profile?project=kubernetes
[2] https://oss-fuzz-build-logs.storage.googleapis.com/log-7522d37e-f347-452c-b00d-cb92498e74f0.txt