### PR TITLE
fix: Replace deprecated ObjectReflectDiff method with cmp.diff

### DIFF
--- a/projects/kubernetes/roundtrip.go
+++ b/projects/kubernetes/roundtrip.go
@@ -41,7 +41,7 @@ import (
 	runtimeserializer "k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apimachinery/pkg/runtime/serializer/json"
 	"k8s.io/apimachinery/pkg/runtime/serializer/protobuf"
-	"k8s.io/apimachinery/pkg/util/diff"
+	"github.com/google/go-cmp/cmp"
 	"k8s.io/apimachinery/pkg/util/sets"
 )
 
@@ -333,7 +333,7 @@ func roundTrip(t *testing.T, scheme *runtime.Scheme, codec runtime.Codec, object
 	object = object.DeepCopyObject()
 	name := reflect.TypeOf(object).Elem().Name()
 	if !apiequality.Semantic.DeepEqual(original, object) {
-		t.Errorf("%v: DeepCopy altered the object, diff: %v", name, diff.ObjectReflectDiff(original, object))
+		t.Errorf("%v: DeepCopy altered the object, diff: %v", name, cmp.Diff(original, object))
 		t.Errorf("%s", spew.Sdump(original))
 		t.Errorf("%s", spew.Sdump(object))
 		return
@@ -354,7 +354,7 @@ func roundTrip(t *testing.T, scheme *runtime.Scheme, codec runtime.Codec, object
 	// copy or conversion should alter the object
 	// TODO eliminate this global
 	if !apiequality.Semantic.DeepEqual(original, object) {
-		t.Errorf("%v: encode altered the object, diff: %v", name, diff.ObjectReflectDiff(original, object))
+		t.Errorf("%v: encode altered the object, diff: %v", name, cmp.Diff(original, object))
 		return
 	}
 
@@ -385,7 +385,7 @@ func roundTrip(t *testing.T, scheme *runtime.Scheme, codec runtime.Codec, object
 	// ensure that the object produced from decoding the encoded data is equal
 	// to the original object
 	if !apiequality.Semantic.DeepEqual(original, obj2) {
-		t.Errorf("%v: diff: %v\nCodec: %#v\nSource:\n\n%#v\n\nEncoded:\n\n%s\n\nFinal:\n\n%#v", name, diff.ObjectReflectDiff(original, obj2), codec, printer.Sprintf("%#v", original), dataAsString(data), printer.Sprintf("%#v", obj2))
+		t.Errorf("%v: diff: %v\nCodec: %#v\nSource:\n\n%#v\n\nEncoded:\n\n%s\n\nFinal:\n\n%#v", name, cmp.Diff(original, obj2), codec, printer.Sprintf("%#v", original), dataAsString(data), printer.Sprintf("%#v", obj2))
 		return
 	}
 
@@ -423,7 +423,7 @@ func roundTrip(t *testing.T, scheme *runtime.Scheme, codec runtime.Codec, object
 	// ensure that the new runtime object is equal to the original after being
 	// decoded into
 	if !apiequality.Semantic.DeepEqual(object, obj3) {
-		t.Errorf("%v: diff: %v\nCodec: %#v", name, diff.ObjectReflectDiff(object, obj3), codec)
+		t.Errorf("%v: diff: %v\nCodec: %#v", name, cmp.Diff(object, obj3), codec)
 		return
 	}
 
@@ -432,7 +432,7 @@ func roundTrip(t *testing.T, scheme *runtime.Scheme, codec runtime.Codec, object
 	// NOTE: we use the encoding+decoding here as an alternative, guaranteed deep-copy to compare against.
 	fuzzer.ValueFuzz(object)
 	if !apiequality.Semantic.DeepEqual(original, obj3) {
-		t.Errorf("%v: fuzzing a copy altered the original, diff: %v", name, diff.ObjectReflectDiff(original, obj3))
+		t.Errorf("%v: fuzzing a copy altered the original, diff: %v", name, cmp.Diff(original, obj3))
 		return
 	}
 }


### PR DESCRIPTION
This pull request replaces the deprecated ObjectReflectDiff calls with the cmp.Diff call, as referenced in the K8s docs (https://pkg.go.dev/k8s.io/apimachinery/pkg/util/diff/ObjectReflectDiff).

I ran an OSS-Fuzz build and fuzzed locally via helper.py, and it worked like a charm.