### PR TITLE
cilium: Add logger to Labelsfilter fuzzer

### DIFF
--- a/projects/cilium/build.sh
+++ b/projects/cilium/build.sh
@@ -32,5 +32,5 @@ cd $SRC/proxy
 mv $CILIUM/OnData_fuzzer.go $SRC/proxy/proxylib/cassandra/
 mv $SRC/proxy/proxylib/cassandra/cassandraparser_test.go $SRC/proxy/proxylib/cassandra/cassandraparser_test_fuzz.go
 go mod tidy && go mod vendor
-CXXFLAGS="${CXXFLAGS} -lpthread -lresolv" compile_go_fuzzer github.com/cilium/proxy/proxylib/cassandra FuzzMultipleParsers fuzz_multiple_parsers
+compile_go_fuzzer github.com/cilium/proxy/proxylib/cassandra FuzzMultipleParsers fuzz_multiple_parsers
 cd -

--- a/projects/cilium/labelsfilter_fuzzer.go
+++ b/projects/cilium/labelsfilter_fuzzer.go
@@ -18,6 +18,8 @@ package labelsfilter
 import (
 	"encoding/json"
 	"fmt"
+	"io"
+	"log/slog"
 	"os"
 
 	fuzz "github.com/AdaLogics/go-fuzz-headers"
@@ -67,7 +69,8 @@ func FuzzLabelsfilterPkg(data []byte) int {
 		return 0
 	}
 
-	err = ParseLabelPrefixCfg(nil, prefixes, nil, "file")
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	err = ParseLabelPrefixCfg(logger, prefixes, nil, "file")
 	if err != nil {
 		fmt.Println(err)
 		return 0


### PR DESCRIPTION
`ParseLabelPrefixCfg` panics when a nil logger is passed.

See: https://github.com/cilium/cilium/pull/40728