### PR TITLE
cilium: Override proxylib.LogFatal

### DIFF
--- a/projects/cilium/OnData_fuzzer.go
+++ b/projects/cilium/OnData_fuzzer.go
@@ -19,6 +19,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"errors"
+	"fmt"
 	"strings"
 
 	"github.com/cilium/proxy/proxylib/accesslog"
@@ -44,6 +45,9 @@ func init() {
 	s.logServer = test.StartAccessLogServer("access_log.sock", 10)
 	s.ins = proxylib.NewInstance("node1", accesslog.NewClient(s.logServer.Path))
 	logrus.SetLevel(logrus.PanicLevel)
+	proxylib.LogFatal = func(format string, args ...interface{}) {
+		fmt.Sprintf(format, args...)
+	}
 }
 
 // Sets the parser type

--- a/projects/cilium/build.sh
+++ b/projects/cilium/build.sh
@@ -14,7 +14,6 @@ go mod tidy && go mod vendor
 # Disable logging
 sed -i 's/logrus\.InfoLevel/logrus.PanicLevel/g' $SRC/cilium/pkg/logging/logging.go
 
-compile_native_go_fuzzer github.com/cilium/cilium/pkg/policy FuzzTest Fuzz_resolveEgressPolicy
 compile_go_fuzzer github.com/cilium/cilium/pkg/labelsfilter FuzzLabelsfilterPkg fuzz_labelsfilter_pkg
 compile_go_fuzzer github.com/cilium/cilium/pkg/monitor/format FuzzFormatEvent fuzz_FormatEvent
 compile_go_fuzzer github.com/cilium/cilium/pkg/fqdn/matchpattern FuzzMatchpatternValidate fuzz_matchpattern_validate

--- a/projects/cilium/build.sh
+++ b/projects/cilium/build.sh
@@ -14,9 +14,6 @@ go mod tidy && go mod vendor
 # Disable logging
 sed -i 's/logrus\.InfoLevel/logrus.PanicLevel/g' $SRC/cilium/pkg/logging/logging.go
 
-compile_native_go_fuzzer github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2 FuzzCiliumNetworkPolicyParse FuzzCiliumNetworkPolicyParse
-compile_native_go_fuzzer github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2 FuzzCiliumClusterwideNetworkPolicyParse FuzzCiliumClusterwideNetworkPolicyParse
-
 compile_native_go_fuzzer github.com/cilium/cilium/pkg/policy FuzzTest Fuzz_resolveEgressPolicy
 compile_go_fuzzer github.com/cilium/cilium/pkg/labelsfilter FuzzLabelsfilterPkg fuzz_labelsfilter_pkg
 compile_go_fuzzer github.com/cilium/cilium/pkg/monitor/format FuzzFormatEvent fuzz_FormatEvent

--- a/projects/cilium/build.sh
+++ b/projects/cilium/build.sh
@@ -23,7 +23,6 @@ compile_go_fuzzer github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/labels FuzzLabe
 
 rm $SRC/cilium/pkg/lock/lock_debug.go
 
-ln -s $SRC/proxy $GOPATH/src/github.com/cilium/proxy
 cd $SRC/proxy
 mv $CILIUM/OnData_fuzzer.go $SRC/proxy/proxylib/cassandra/
 mv $SRC/proxy/proxylib/cassandra/cassandraparser_test.go $SRC/proxy/proxylib/cassandra/cassandraparser_test_fuzz.go


### PR DESCRIPTION
The current test utils call logrus.Fatalf, which causes the fuzzer to exit with status code 1, which breaks the test harness. See cilium/proxy#1487 and https://github.com/cilium/cilium/pull/40728

Also removing some more unneeded fuzzers.